### PR TITLE
 Add language grouping and rollover info on locales

### DIFF
--- a/public/list_one.xml
+++ b/public/list_one.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Source: https://www.currency-iso.org/dam/downloads/lists/list_one.xml -->
+<!-- Source: https://www.currency-iso.org/dam/downloads/lists/list_one.xml (saved 14 Jun 2018) -->
 <!-- TODO:  find out if there would be a way to load directly from there -->
 <ISO_4217 Pblshd="2018-01-01">
 	<CcyTbl>

--- a/src/CurrencyTable/CurrencyTable.js
+++ b/src/CurrencyTable/CurrencyTable.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import {Link, Tooltip} from '@shopify/polaris';
 import autoBind from 'react-autobind';
 import styles from './CurrencyTable.scss';
+import countryCodes from '../Resources/CountryCodes.json';
+import languageCodes from '../Resources/LanguageCodes.json';
 
 
 class CurrencyTable extends Component {
@@ -24,11 +26,27 @@ class CurrencyTable extends Component {
 
   currencyRow(currency, index) {
     const {locales} = this.props;
-    const formattedValues = locales.map((locale, index) => (
-      <span key={`val_${index}`}>
-        {new Intl.NumberFormat(locale, {style: 'currency', currency: currency.code}).format(9.99)}
-      </span>
-      )
+    let prevLanguage = '';
+    let colouredColumn = true;
+    const formattedValues = locales.map((locale, index) => {
+
+      // Colour coding of language groups  //  TODO:  make separate fct ??
+      const thirdLetter = locale.substr(2, 1);
+      const language = (thirdLetter === ' ' || thirdLetter === '-') 
+        ? locale.substr(0, 2)
+        : locale.substr(0, 3);
+      if (language !== prevLanguage) {
+        prevLanguage = language;
+        colouredColumn = !colouredColumn;
+      }
+      const colourClass = (colouredColumn) ? 'coloured-column' : '';
+
+      return (
+        <span key={`val_${index}`} className={`${colourClass}`}>
+          {new Intl.NumberFormat(locale, {style: 'currency', currency: currency.code}).format(9.99)}
+        </span>
+      );
+    }
     );
     return <div className="trow" key={`row_${index}`}>{formattedValues}</div>;
     //  ???  would it be preferable to use a for loop to push individual formatted values onto [rowHeading] to avoid
@@ -40,7 +58,12 @@ class CurrencyTable extends Component {
     return (currencies.map((currency, index) => (
           <div className="trow" key={`cur_${index}`}>
             <span>
-              <Tooltip content={JSON.stringify(currency.countries, null, 1)}>
+              <Tooltip content={JSON.stringify(currency.countries, null, 1)
+                  .replace('[', '')
+                  .replace(']', '')
+                  .replace(/"/g, '')
+                }
+              >
                 <Link><b>{currency.code}</b><br />{currency.name}</Link>
               </Tooltip>
             </span>
@@ -51,8 +74,32 @@ class CurrencyTable extends Component {
   }
 
   localeHeadings() {
-    const {locales} = this.props;
-    return (locales.map((locale, index) => <span key={`loc_${index}`}>{locale}</span>));
+    const {locales} = this.props;   
+    
+    return (locales.map((locale, index) => {
+      
+      // Country & Language rollover info
+      const countryCodeMatch = locale.match(/[A-Z][A-Z]/);
+      const countryCode = (countryCodeMatch) ? countryCodeMatch[0] : null;
+      const languageCodeMatch = locale.match(/\w\w\w?/);
+      const languageCode = (languageCodeMatch) ? languageCodeMatch[0] : null;
+      let tooltip;
+      const country = (countryCode) ? countryCodes.Countries[countryCode] : null;
+      const countryName = (country) ? `(${country.name})` : '';
+      const countryFile = (country) ? country.file : null;
+      const language = (languageCode) ? languageCodes.Languages[languageCode].name : null;
+      if (language || countryName) {
+        const link = 
+          <Link 
+            url={(countryFile) ? `http://www.nationsonline.org/oneworld/${countryFile}` : '#'} 
+            external={true}>
+              {locale}
+          </Link>;
+        tooltip = <Tooltip content={`${language} ${countryName}`}>{link}</Tooltip>;
+      }
+
+      return (<span key={`loc_${index}`}>{tooltip || locale}</span>);
+    }));
   }
 
   componentDidMount() {

--- a/src/Resources/CountryCodes.json
+++ b/src/Resources/CountryCodes.json
@@ -1,0 +1,1486 @@
+{
+  "Countries": {
+    "AD": {
+      "flag": "AND",
+      "file": "andorra.htm",
+      "name": "Andorra",
+      "code": "AD"
+    },
+    "AE": {
+      "flag": "ARE",
+      "file": "arab_emirates.htm",
+      "name": "United Arab Emirates",
+      "code": "AE"
+    },
+    "AF": {
+      "flag": "AFG",
+      "file": "afghanistan.htm",
+      "name": "Afghanistan",
+      "code": "AF"
+    },
+    "AG": {
+      "flag": "ATG",
+      "file": "antigua_barbuda.htm",
+      "name": "Antigua and Barbuda",
+      "code": "AG"
+    },
+    "AI": {
+      "flag": "AIA",
+      "file": "anguilla.htm",
+      "name": "Anguilla",
+      "code": "AI"
+    },
+    "AL": {
+      "flag": "ALB",
+      "file": "albania.htm",
+      "name": "Albania",
+      "code": "AL"
+    },
+    "AM": {
+      "flag": "ARM",
+      "file": "armenia.htm",
+      "name": "Armenia",
+      "code": "AM"
+    },
+    "AN": {
+      "flag": "ANT",
+      "file": "netherlands_antilles.htm",
+      "name": "Netherlands Antilles",
+      "code": "AN"
+    },
+    "AO": {
+      "flag": "AGO",
+      "file": "angola.htm",
+      "name": "Angola",
+      "code": "AO"
+    },
+    "AQ": {
+      "flag": "",
+      "file": "",
+      "name": "Antarctica",
+      "code": "AQ"
+    },
+    "AR": {
+      "flag": "ARG",
+      "file": "argentina.htm",
+      "name": "Argentina",
+      "code": "AR"
+    },
+    "AS": {
+      "flag": "ASM",
+      "file": "american_samoa.htm",
+      "name": "American Samoa",
+      "code": "AS"
+    },
+    "AT": {
+      "flag": "AUT",
+      "file": "austria.htm",
+      "name": "Austria",
+      "code": "AT"
+    },
+    "AU": {
+      "flag": "AUS",
+      "file": "australia.htm",
+      "name": "Australia",
+      "code": "AU"
+    },
+    "AW": {
+      "flag": "ABW",
+      "file": "aruba.htm",
+      "name": "Aruba",
+      "code": "AW"
+    },
+    "AX": {
+      "flag": "ALA",
+      "file": "",
+      "name": "Aland Islands",
+      "code": "AX"
+    },
+    "AZ": {
+      "flag": "AZE",
+      "file": "azerbaijan.htm",
+      "name": "Azerbaijan",
+      "code": "AZ"
+    },
+    "BA": {
+      "flag": "BIH",
+      "file": "bosnia_herzegovina.htm",
+      "name": "Bosnia and Herzegovina",
+      "code": "BA"
+    },
+    "BB": {
+      "flag": "BRB",
+      "file": "barbados.htm",
+      "name": "Barbados",
+      "code": "BB"
+    },
+    "BD": {
+      "flag": "BGD",
+      "file": "bangladesh.htm",
+      "name": "Bangladesh",
+      "code": "BD"
+    },
+    "BE": {
+      "flag": "BEL",
+      "file": "belgium.htm",
+      "name": "Belgium",
+      "code": "BE"
+    },
+    "BF": {
+      "flag": "BFA",
+      "file": "burkina_faso.htm",
+      "name": "Burkina Faso",
+      "code": "BF"
+    },
+    "BG": {
+      "flag": "BGR",
+      "file": "bulgaria.htm",
+      "name": "Bulgaria",
+      "code": "BG"
+    },
+    "BH": {
+      "flag": "BHR",
+      "file": "bahrain.htm",
+      "name": "Bahrain",
+      "code": "BH"
+    },
+    "BI": {
+      "flag": "BDI",
+      "file": "burundi.htm",
+      "name": "Burundi",
+      "code": "BI"
+    },
+    "BJ": {
+      "flag": "BEN",
+      "file": "benin.htm",
+      "name": "Benin",
+      "code": "BJ"
+    },
+    "BL": {
+      "flag": "BLM",
+      "file": "",
+      "name": "Saint-Barthélemy",
+      "code": "BL"
+    },
+    "BM": {
+      "flag": "BMU",
+      "file": "bermuda.htm",
+      "name": "Bermuda",
+      "code": "BM"
+    },
+    "BN": {
+      "flag": "BRN",
+      "file": "brunei.htm",
+      "name": "Brunei Darussalam",
+      "code": "BN"
+    },
+    "BO": {
+      "flag": "BOL",
+      "file": "bolivia.htm",
+      "name": "Bolivia",
+      "code": "BO"
+    },
+    "BR": {
+      "flag": "BRA",
+      "file": "brazil.htm",
+      "name": "Brazil",
+      "code": "BR"
+    },
+    "BS": {
+      "flag": "BHS",
+      "file": "bahamas.htm",
+      "name": "Bahamas",
+      "code": "BS"
+    },
+    "BT": {
+      "flag": "BTN",
+      "file": "bhutan.htm",
+      "name": "Bhutan",
+      "code": "BT"
+    },
+    "BV": {
+      "flag": "BVT",
+      "file": "",
+      "name": "Bouvet Island",
+      "code": "BV"
+    },
+    "BW": {
+      "flag": "BWA",
+      "file": "botswana.htm",
+      "name": "Botswana",
+      "code": "BW"
+    },
+    "BY": {
+      "flag": "BLR",
+      "file": "belarus.htm",
+      "name": "Belarus",
+      "code": "BY"
+    },
+    "BZ": {
+      "flag": "BLZ",
+      "file": "belize.htm",
+      "name": "Belize",
+      "code": "BZ"
+    },
+    "CA": {
+      "flag": "CAN",
+      "file": "canada.htm",
+      "name": "Canada",
+      "code": "CA"
+    },
+    "CC": {
+      "flag": "CCK",
+      "file": "",
+      "name": "Cocos (Keeling) Islands",
+      "code": "CC"
+    },
+    "CD": {
+      "flag": "COD",
+      "file": "congo_droc.htm",
+      "name": "Congo (Kinshasa)",
+      "code": "CD"
+    },
+    "CF": {
+      "flag": "CAF",
+      "file": "central_african_republic.htm",
+      "name": "Central African Republic",
+      "code": "CF"
+    },
+    "CG": {
+      "flag": "COG",
+      "file": "congo_roc.htm",
+      "name": "Congo (Brazzaville)",
+      "code": "CG"
+    },
+    "CH": {
+      "flag": "CHE",
+      "file": "switzerland.htm",
+      "name": "Switzerland",
+      "code": "CH"
+    },
+    "CI": {
+      "flag": "CIV",
+      "file": "cote_d_ivoire.htm",
+      "name": "Côte d'Ivoire",
+      "code": "CI"
+    },
+    "CK": {
+      "flag": "COK",
+      "file": "",
+      "name": "Cook Islands",
+      "code": "CK"
+    },
+    "CL": {
+      "flag": "CHL",
+      "file": "chile.htm",
+      "name": "Chile",
+      "code": "CL"
+    },
+    "CM": {
+      "flag": "CMR",
+      "file": "cameroon.htm",
+      "name": "Cameroon",
+      "code": "CM"
+    },
+    "CN": {
+      "flag": "CHN",
+      "file": "china.htm",
+      "name": "China",
+      "code": "CN"
+    },
+    "CO": {
+      "flag": "COL",
+      "file": "colombia.htm",
+      "name": "Colombia",
+      "code": "CO"
+    },
+    "CR": {
+      "flag": "CRI",
+      "file": "costa_rica.htm",
+      "name": "Costa Rica",
+      "code": "CR"
+    },
+    "CU": {
+      "flag": "CUB",
+      "file": "cuba.htm",
+      "name": "Cuba",
+      "code": "CU"
+    },
+    "CV": {
+      "flag": "CPV",
+      "file": "cape_verde.htm",
+      "name": "Cape Verde",
+      "code": "CV"
+    },
+    "CX": {
+      "flag": "CXR",
+      "file": "",
+      "name": "Christmas Island",
+      "code": "CX"
+    },
+    "CY": {
+      "flag": "CYP",
+      "file": "cyprus.htm",
+      "name": "Cyprus",
+      "code": "CY"
+    },
+    "CZ": {
+      "flag": "CZE",
+      "file": "czech_republic.htm",
+      "name": "Czech Republic",
+      "code": "CZ"
+    },
+    "DE": {
+      "flag": "DEU",
+      "file": "germany.htm",
+      "name": "Germany",
+      "code": "DE"
+    },
+    "DJ": {
+      "flag": "DJI",
+      "file": "djibouti.htm",
+      "name": "Djibouti",
+      "code": "DJ"
+    },
+    "DK": {
+      "flag": "DNK",
+      "file": "denmark.htm",
+      "name": "Denmark",
+      "code": "DK"
+    },
+    "DM": {
+      "flag": "DMA",
+      "file": "dominica.htm",
+      "name": "Dominica",
+      "code": "DM"
+    },
+    "DO": {
+      "flag": "DOM",
+      "file": "dominican_republic.htm",
+      "name": "Dominican Republic",
+      "code": "DO"
+    },
+    "DZ": {
+      "flag": "DZA",
+      "file": "algeria.htm",
+      "name": "Algeria",
+      "code": "DZ"
+    },
+    "EC": {
+      "flag": "ECU",
+      "file": "ecuador.htm",
+      "name": "Ecuador",
+      "code": "EC"
+    },
+    "EE": {
+      "flag": "EST",
+      "file": "estonia.htm",
+      "name": "Estonia",
+      "code": "EE"
+    },
+    "EG": {
+      "flag": "EGY",
+      "file": "egypt.htm",
+      "name": "Egypt",
+      "code": "EG"
+    },
+    "EH": {
+      "flag": "ESH",
+      "file": "",
+      "name": "Western Sahara",
+      "code": "EH"
+    },
+    "ER": {
+      "flag": "ERI",
+      "file": "eritrea.htm",
+      "name": "Eritrea",
+      "code": "ER"
+    },
+    "ES": {
+      "flag": "ESP",
+      "file": "spain.htm",
+      "name": "Spain",
+      "code": "ES"
+    },
+    "ET": {
+      "flag": "ETH",
+      "file": "ethiopia.htm",
+      "name": "Ethiopia",
+      "code": "ET"
+    },
+    "FI": {
+      "flag": "FIN",
+      "file": "finland.htm",
+      "name": "Finland",
+      "code": "FI"
+    },
+    "FJ": {
+      "flag": "FJI",
+      "file": "fiji.htm",
+      "name": "Fiji",
+      "code": "FJ"
+    },
+    "FK": {
+      "flag": "FLK",
+      "file": "",
+      "name": "Falkland Islands (Malvinas)",
+      "code": "FK"
+    },
+    "FM": {
+      "flag": "FSM",
+      "file": "micronesia.htm",
+      "name": "Micronesia, Federated States of",
+      "code": "FM"
+    },
+    "FO": {
+      "flag": "FRO",
+      "file": "faroe_islands.htm",
+      "name": "Faroe Islands",
+      "code": "FO"
+    },
+    "FR": {
+      "flag": "FRA",
+      "file": "france.htm",
+      "name": "France",
+      "code": "FR"
+    },
+    "GA": {
+      "flag": "GAB",
+      "file": "gabon.htm",
+      "name": "Gabon",
+      "code": "GA"
+    },
+    "GB": {
+      "flag": "GBR",
+      "file": "united_kingdom.htm",
+      "name": "United Kingdom",
+      "code": "GB"
+    },
+    "GD": {
+      "flag": "GRD",
+      "file": "grenada.htm",
+      "name": "Grenada",
+      "code": "GD"
+    },
+    "GE": {
+      "flag": "GEO",
+      "file": "georgia.htm",
+      "name": "Georgia",
+      "code": "GE"
+    },
+    "GF": {
+      "flag": "GUF",
+      "file": "french_guiana.htm",
+      "name": "French Guiana",
+      "code": "GF"
+    },
+    "GG": {
+      "flag": "GGY",
+      "file": "",
+      "name": "Guernsey",
+      "code": "GG"
+    },
+    "GH": {
+      "flag": "GHA",
+      "file": "ghana.htm",
+      "name": "Ghana",
+      "code": "GH"
+    },
+    "GI": {
+      "flag": "GIB",
+      "file": "",
+      "name": "Gibraltar",
+      "code": "GI"
+    },
+    "GL": {
+      "flag": "GRL",
+      "file": "greenland.htm",
+      "name": "Greenland",
+      "code": "GL"
+    },
+    "GM": {
+      "flag": "GMB",
+      "file": "gambia.htm",
+      "name": "Gambia",
+      "code": "GM"
+    },
+    "GN": {
+      "flag": "GIN",
+      "file": "guinea.htm",
+      "name": "Guinea",
+      "code": "GN"
+    },
+    "GP": {
+      "flag": "GLP",
+      "file": "guadeloupe.htm",
+      "name": "Guadeloupe",
+      "code": "GP"
+    },
+    "GQ": {
+      "flag": "GNQ",
+      "file": "equatorial_guinea.htm",
+      "name": "Equatorial Guinea",
+      "code": "GQ"
+    },
+    "GR": {
+      "flag": "GRC",
+      "file": "greece.htm",
+      "name": "Greece",
+      "code": "GR"
+    },
+    "GS": {
+      "flag": "SGS",
+      "file": "",
+      "name": "South Georgia and the South Sandwich Islands",
+      "code": "GS"
+    },
+    "GT": {
+      "flag": "GTM",
+      "file": "guatemala.htm",
+      "name": "Guatemala",
+      "code": "GT"
+    },
+    "GU": {
+      "flag": "GUM",
+      "file": "guam.htm",
+      "name": "Guam",
+      "code": "GU"
+    },
+    "GW": {
+      "flag": "GNB",
+      "file": "guinea_bissau.htm",
+      "name": "Guinea-Bissau",
+      "code": "GW"
+    },
+    "GY": {
+      "flag": "GUY",
+      "file": "guyana.htm",
+      "name": "Guyana",
+      "code": "GY"
+    },
+    "HK": {
+      "flag": "HKG",
+      "file": "hong_kong.htm",
+      "name": "Hong Kong, SAR China",
+      "code": "HK"
+    },
+    "HM": {
+      "flag": "HMD",
+      "file": "",
+      "name": "Heard and Mcdonald Islands",
+      "code": "HM"
+    },
+    "HN": {
+      "flag": "HND",
+      "file": "honduras.htm",
+      "name": "Honduras",
+      "code": "HN"
+    },
+    "HR": {
+      "flag": "HRV",
+      "file": "croatia.htm",
+      "name": "Croatia",
+      "code": "HR"
+    },
+    "HT": {
+      "flag": "HTI",
+      "file": "haiti.htm",
+      "name": "Haiti",
+      "code": "HT"
+    },
+    "HU": {
+      "flag": "HUN",
+      "file": "hungary.htm",
+      "name": "Hungary",
+      "code": "HU"
+    },
+    "ID": {
+      "flag": "IDN",
+      "file": "indonesia.htm",
+      "name": "Indonesia",
+      "code": "ID"
+    },
+    "IE": {
+      "flag": "IRL",
+      "file": "ireland.htm",
+      "name": "Ireland",
+      "code": "IE"
+    },
+    "IL": {
+      "flag": "ISR",
+      "file": "israel.htm",
+      "name": "Israel",
+      "code": "IL"
+    },
+    "IM": {
+      "flag": "IMN",
+      "file": "",
+      "name": "Isle of Man",
+      "code": "IM"
+    },
+    "IN": {
+      "flag": "IND",
+      "file": "india.htm",
+      "name": "India",
+      "code": "IN"
+    },
+    "IO": {
+      "flag": "IOT",
+      "file": "",
+      "name": "British Indian Ocean Territory",
+      "code": "IO"
+    },
+    "IQ": {
+      "flag": "IRQ",
+      "file": "iraq.htm",
+      "name": "Iraq",
+      "code": "IQ"
+    },
+    "IR": {
+      "flag": "IRN",
+      "file": "iran.htm",
+      "name": "Iran, Islamic Republic of",
+      "code": "IR"
+    },
+    "IS": {
+      "flag": "ISL",
+      "file": "iceland.htm",
+      "name": "Iceland",
+      "code": "IS"
+    },
+    "IT": {
+      "flag": "ITA",
+      "file": "italy.htm",
+      "name": "Italy",
+      "code": "IT"
+    },
+    "JE": {
+      "flag": "JEY",
+      "file": "",
+      "name": "Jersey",
+      "code": "JE"
+    },
+    "JM": {
+      "flag": "JAM",
+      "file": "jamaica.htm",
+      "name": "Jamaica",
+      "code": "JM"
+    },
+    "JO": {
+      "flag": "JOR",
+      "file": "jordan.htm",
+      "name": "Jordan",
+      "code": "JO"
+    },
+    "JP": {
+      "flag": "JPN",
+      "file": "japan.htm",
+      "name": "Japan",
+      "code": "JP"
+    },
+    "KE": {
+      "flag": "KEN",
+      "file": "kenya.htm",
+      "name": "Kenya",
+      "code": "KE"
+    },
+    "KG": {
+      "flag": "KGZ",
+      "file": "kyrgyzstan.htm",
+      "name": "Kyrgyzstan",
+      "code": "KG"
+    },
+    "KH": {
+      "flag": "KHM",
+      "file": "cambodia.htm",
+      "name": "Cambodia",
+      "code": "KH"
+    },
+    "KI": {
+      "flag": "KIR",
+      "file": "kiribati.htm",
+      "name": "Kiribati",
+      "code": "KI"
+    },
+    "KM": {
+      "flag": "COM",
+      "file": "comoros.htm",
+      "name": "Comoros",
+      "code": "KM"
+    },
+    "KN": {
+      "flag": "KNA",
+      "file": "saint_kitts_nevis.htm",
+      "name": "Saint Kitts and Nevis",
+      "code": "KN"
+    },
+    "KP": {
+      "flag": "PRK",
+      "file": "korea_north.htm",
+      "name": "Korea (North)",
+      "code": "KP"
+    },
+    "KR": {
+      "flag": "KOR",
+      "file": "korea_south.htm",
+      "name": "Korea (South)",
+      "code": "KR"
+    },
+    "KW": {
+      "flag": "KWT",
+      "file": "kuwait.htm",
+      "name": "Kuwait",
+      "code": "KW"
+    },
+    "KY": {
+      "flag": "CYM",
+      "file": "",
+      "name": "Cayman Islands",
+      "code": "KY"
+    },
+    "KZ": {
+      "flag": "KAZ",
+      "file": "kazakhstan.htm",
+      "name": "Kazakhstan",
+      "code": "KZ"
+    },
+    "LA": {
+      "flag": "LAO",
+      "file": "laos.htm",
+      "name": "Lao PDR",
+      "code": "LA"
+    },
+    "LB": {
+      "flag": "LBN",
+      "file": "lebanon.htm",
+      "name": "Lebanon",
+      "code": "LB"
+    },
+    "LC": {
+      "flag": "LCA",
+      "file": "saint_lucia.htm",
+      "name": "Saint Lucia",
+      "code": "LC"
+    },
+    "LI": {
+      "flag": "LIE",
+      "file": "liechtenstein.htm",
+      "name": "Liechtenstein",
+      "code": "LI"
+    },
+    "LK": {
+      "flag": "LKA",
+      "file": "sri_lanka.htm",
+      "name": "Sri Lanka",
+      "code": "LK"
+    },
+    "LR": {
+      "flag": "LBR",
+      "file": "liberia.htm",
+      "name": "Liberia",
+      "code": "LR"
+    },
+    "LS": {
+      "flag": "LSO",
+      "file": "lesotho.htm",
+      "name": "Lesotho",
+      "code": "LS"
+    },
+    "LT": {
+      "flag": "LTU",
+      "file": "lithuania.htm",
+      "name": "Lithuania",
+      "code": "LT"
+    },
+    "LU": {
+      "flag": "LUX",
+      "file": "luxembourg.htm",
+      "name": "Luxembourg",
+      "code": "LU"
+    },
+    "LV": {
+      "flag": "LVA",
+      "file": "latvia.htm",
+      "name": "Latvia",
+      "code": "LV"
+    },
+    "LY": {
+      "flag": "LBY",
+      "file": "libya.htm",
+      "name": "Libya",
+      "code": "LY"
+    },
+    "MA": {
+      "flag": "MAR",
+      "file": "morocco.htm",
+      "name": "Morocco",
+      "code": "MA"
+    },
+    "MC": {
+      "flag": "MCO",
+      "file": "monaco.htm",
+      "name": "Monaco",
+      "code": "MC"
+    },
+    "MD": {
+      "flag": "MDA",
+      "file": "moldova.htm",
+      "name": "Moldova",
+      "code": "MD"
+    },
+    "ME": {
+      "flag": "MNE",
+      "file": "montenegro.htm",
+      "name": "Montenegro",
+      "code": "ME"
+    },
+    "MF": {
+      "flag": "MAF",
+      "file": "",
+      "name": " Saint-Martin (French part)",
+      "code": "MF"
+    },
+    "MG": {
+      "flag": "MDG",
+      "file": "madagascar.htm",
+      "name": "Madagascar",
+      "code": "MG"
+    },
+    "MH": {
+      "flag": "MHL",
+      "file": "marshall_islands.htm",
+      "name": "Marshall Islands",
+      "code": "MH"
+    },
+    "MK": {
+      "flag": "MKD",
+      "file": "macedonia_rep.htm",
+      "name": "Macedonia, Republic of",
+      "code": "MK"
+    },
+    "ML": {
+      "flag": "MLI",
+      "file": "mali.htm",
+      "name": "Mali",
+      "code": "ML"
+    },
+    "MM": {
+      "flag": "MMR",
+      "file": "myanmar.htm",
+      "name": "Myanmar",
+      "code": "MM"
+    },
+    "MN": {
+      "flag": "MNG",
+      "file": "mongolia.htm",
+      "name": "Mongolia",
+      "code": "MN"
+    },
+    "MO": {
+      "flag": "MAC",
+      "file": "macau.htm",
+      "name": "Macao, SAR China",
+      "code": "MO"
+    },
+    "MP": {
+      "flag": "MNP",
+      "file": "northern_mariana_islands.htm",
+      "name": "Northern Mariana Islands",
+      "code": "MP"
+    },
+    "MQ": {
+      "flag": "MTQ",
+      "file": "martinique.htm",
+      "name": "Martinique",
+      "code": "MQ"
+    },
+    "MR": {
+      "flag": "MRT",
+      "file": "mauritania.htm",
+      "name": "Mauritania",
+      "code": "MR"
+    },
+    "MS": {
+      "flag": "MSR",
+      "file": "montserrat.htm",
+      "name": "Montserrat",
+      "code": "MS"
+    },
+    "MT": {
+      "flag": "MLT",
+      "file": "malta.htm",
+      "name": "Malta",
+      "code": "MT"
+    },
+    "MU": {
+      "flag": "MUS",
+      "file": "mauritius.htm",
+      "name": "Mauritius",
+      "code": "MU"
+    },
+    "MV": {
+      "flag": "MDV",
+      "file": "maldives.htm",
+      "name": "Maldives",
+      "code": "MV"
+    },
+    "MW": {
+      "flag": "MWI",
+      "file": "malawi.htm",
+      "name": "Malawi",
+      "code": "MW"
+    },
+    "MX": {
+      "flag": "MEX",
+      "file": "mexico.htm",
+      "name": "Mexico",
+      "code": "MX"
+    },
+    "MY": {
+      "flag": "MYS",
+      "file": "malaysia.htm",
+      "name": "Malaysia",
+      "code": "MY"
+    },
+    "MZ": {
+      "flag": "MOZ",
+      "file": "mozambique.htm",
+      "name": "Mozambique",
+      "code": "MZ"
+    },
+    "NA": {
+      "flag": "NAM",
+      "file": "namibia.htm",
+      "name": "Namibia",
+      "code": "NA"
+    },
+    "NC": {
+      "flag": "NCL",
+      "file": "new_caledonia.htm",
+      "name": "New Caledonia",
+      "code": "NC"
+    },
+    "NE": {
+      "flag": "NER",
+      "file": "niger.htm",
+      "name": "Niger",
+      "code": "NE"
+    },
+    "NF": {
+      "flag": "NFK",
+      "file": "",
+      "name": "Norfolk Island",
+      "code": "NF"
+    },
+    "NG": {
+      "flag": "NGA",
+      "file": "nigeria.htm",
+      "name": "Nigeria",
+      "code": "NG"
+    },
+    "NI": {
+      "flag": "NIC",
+      "file": "nicaragua.htm",
+      "name": "Nicaragua",
+      "code": "NI"
+    },
+    "NL": {
+      "flag": "NLD",
+      "file": "netherlands.htm",
+      "name": "Netherlands",
+      "code": "NL"
+    },
+    "NO": {
+      "flag": "NOR",
+      "file": "norway.htm",
+      "name": "Norway",
+      "code": "NO"
+    },
+    "NP": {
+      "flag": "NPL",
+      "file": "nepal.htm",
+      "name": "Nepal",
+      "code": "NP"
+    },
+    "NR": {
+      "flag": "NRU",
+      "file": "nauru.htm",
+      "name": "Nauru",
+      "code": "NR"
+    },
+    "NU": {
+      "flag": "NIU",
+      "file": "",
+      "name": "Niue",
+      "code": "NU"
+    },
+    "NZ": {
+      "flag": "NZL",
+      "file": "new_zealand.htm",
+      "name": "New Zealand",
+      "code": "NZ"
+    },
+    "OM": {
+      "flag": "OMN",
+      "file": "oman.htm",
+      "name": "Oman",
+      "code": "OM"
+    },
+    "PA": {
+      "flag": "PAN",
+      "file": "panama.htm",
+      "name": "Panama",
+      "code": "PA"
+    },
+    "PE": {
+      "flag": "PER",
+      "file": "peru.htm",
+      "name": "Peru",
+      "code": "PE"
+    },
+    "PF": {
+      "flag": "PYF",
+      "file": "french_polynesia.htm",
+      "name": "French Polynesia",
+      "code": "PF"
+    },
+    "PG": {
+      "flag": "PNG",
+      "file": "papua_new_guinea.htm",
+      "name": "Papua New Guinea",
+      "code": "PG"
+    },
+    "PH": {
+      "flag": "PHL",
+      "file": "philippines.htm",
+      "name": "Philippines",
+      "code": "PH"
+    },
+    "PK": {
+      "flag": "PAK",
+      "file": "pakistan.htm",
+      "name": "Pakistan",
+      "code": "PK"
+    },
+    "PL": {
+      "flag": "POL",
+      "file": "poland.htm",
+      "name": "Poland",
+      "code": "PL"
+    },
+    "PM": {
+      "flag": "SPM",
+      "file": "",
+      "name": "Saint Pierre and Miquelon",
+      "code": "PM"
+    },
+    "PN": {
+      "flag": "PCN",
+      "file": "pitcairn.htm",
+      "name": "Pitcairn",
+      "code": "PN"
+    },
+    "PR": {
+      "flag": "PRI",
+      "file": "puerto_rico.htm",
+      "name": "Puerto Rico",
+      "code": "PR"
+    },
+    "PS": {
+      "flag": "PSE",
+      "file": "palestinian_territory.htm",
+      "name": "Palestinian Territory",
+      "code": "PS"
+    },
+    "PT": {
+      "flag": "PRT",
+      "file": "portugal.htm",
+      "name": "Portugal",
+      "code": "PT"
+    },
+    "PW": {
+      "flag": "PLW",
+      "file": "palau.htm",
+      "name": "Palau",
+      "code": "PW"
+    },
+    "PY": {
+      "flag": "PRY",
+      "file": "paraguay.htm",
+      "name": "Paraguay",
+      "code": "PY"
+    },
+    "QA": {
+      "flag": "QAT",
+      "file": "qatar.htm",
+      "name": "Qatar",
+      "code": "QA"
+    },
+    "RE": {
+      "flag": "REU",
+      "file": "reunion.htm",
+      "name": "Réunion",
+      "code": "RE"
+    },
+    "RO": {
+      "flag": "ROU",
+      "file": "romania.htm",
+      "name": "Romania",
+      "code": "RO"
+    },
+    "RS": {
+      "flag": "SRB",
+      "file": "serbia.htm",
+      "name": "Serbia",
+      "code": "RS"
+    },
+    "RU": {
+      "flag": "RUS",
+      "file": "russia.htm",
+      "name": "Russian Federation",
+      "code": "RU"
+    },
+    "RW": {
+      "flag": "RWA",
+      "file": "rwanda.htm",
+      "name": "Rwanda",
+      "code": "RW"
+    },
+    "SA": {
+      "flag": "SAU",
+      "file": "saudi_arabia.htm",
+      "name": "Saudi Arabia",
+      "code": "SA"
+    },
+    "SB": {
+      "flag": "SLB",
+      "file": "solomon_islands.htm",
+      "name": "Solomon Islands",
+      "code": "SB"
+    },
+    "SC": {
+      "flag": "SYC",
+      "file": "seychelles.htm",
+      "name": "Seychelles",
+      "code": "SC"
+    },
+    "SD": {
+      "flag": "SDN",
+      "file": "sudan.htm",
+      "name": "Sudan",
+      "code": "SD"
+    },
+    "SE": {
+      "flag": "SWE",
+      "file": "sweden.htm",
+      "name": "Sweden",
+      "code": "SE"
+    },
+    "SG": {
+      "flag": "SGP",
+      "file": "singapore.htm",
+      "name": "Singapore",
+      "code": "SG"
+    },
+    "SH": {
+      "flag": "SHN",
+      "file": "",
+      "name": "Saint Helena",
+      "code": "SH"
+    },
+    "SI": {
+      "flag": "SVN",
+      "file": "slovenia.htm",
+      "name": "Slovenia",
+      "code": "SI"
+    },
+    "SJ": {
+      "flag": "SJM",
+      "file": "",
+      "name": "Svalbard and Jan Mayen Islands",
+      "code": "SJ"
+    },
+    "SK": {
+      "flag": "SVK",
+      "file": "slovakia.htm",
+      "name": "Slovakia",
+      "code": "SK"
+    },
+    "SL": {
+      "flag": "SLE",
+      "file": "sierra_leone.htm",
+      "name": "Sierra Leone",
+      "code": "SL"
+    },
+    "SM": {
+      "flag": "SMR",
+      "file": "san_marino.htm",
+      "name": "San Marino",
+      "code": "SM"
+    },
+    "SN": {
+      "flag": "SEN",
+      "file": "senegal.htm",
+      "name": "Senegal",
+      "code": "SN"
+    },
+    "SO": {
+      "flag": "SOM",
+      "file": "somalia.htm",
+      "name": "Somalia",
+      "code": "SO"
+    },
+    "SR": {
+      "flag": "SUR",
+      "file": "suriname.htm",
+      "name": "Suriname",
+      "code": "SR"
+    },
+    "SS": {
+      "flag": "SSD",
+      "file": "",
+      "name": "South Sudan",
+      "code": "SS"
+    },
+    "ST": {
+      "flag": "STP",
+      "file": "sao_tome_principe.htm",
+      "name": "Sao Tome and Principe",
+      "code": "ST"
+    },
+    "SV": {
+      "flag": "SLV",
+      "file": "el_salvador.htm",
+      "name": "El Salvador",
+      "code": "SV"
+    },
+    "SY": {
+      "flag": "SYR",
+      "file": "syria.htm",
+      "name": "Syrian Arab Republic (Syria)",
+      "code": "SY"
+    },
+    "SZ": {
+      "flag": "SWZ",
+      "file": "swaziland.htm",
+      "name": "Swaziland",
+      "code": "SZ"
+    },
+    "TC": {
+      "flag": "TCA",
+      "file": "",
+      "name": "Turks and Caicos Islands",
+      "code": "TC"
+    },
+    "TD": {
+      "flag": "TCD",
+      "file": "chad.htm",
+      "name": "Chad",
+      "code": "TD"
+    },
+    "TF": {
+      "flag": "ATF",
+      "file": "",
+      "name": "French Southern Territories",
+      "code": "TF"
+    },
+    "TG": {
+      "flag": "TGO",
+      "file": "togo.htm",
+      "name": "Togo",
+      "code": "TG"
+    },
+    "TH": {
+      "flag": "THA",
+      "file": "thailand.htm",
+      "name": "Thailand",
+      "code": "TH"
+    },
+    "TJ": {
+      "flag": "TJK",
+      "file": "tajikistan.htm",
+      "name": "Tajikistan",
+      "code": "TJ"
+    },
+    "TK": {
+      "flag": "TKL",
+      "file": "",
+      "name": "Tokelau",
+      "code": "TK"
+    },
+    "TL": {
+      "flag": "TLS",
+      "file": "timor_leste.htm",
+      "name": "Timor-Leste",
+      "code": "TL"
+    },
+    "TM": {
+      "flag": "TKM",
+      "file": "turkmenistan.htm",
+      "name": "Turkmenistan",
+      "code": "TM"
+    },
+    "TN": {
+      "flag": "TUN",
+      "file": "tunisia.htm",
+      "name": "Tunisia",
+      "code": "TN"
+    },
+    "TO": {
+      "flag": "TON",
+      "file": "tonga.htm",
+      "name": "Tonga",
+      "code": "TO"
+    },
+    "TR": {
+      "flag": "TUR",
+      "file": "turkey.htm",
+      "name": "Turkey",
+      "code": "TR"
+    },
+    "TT": {
+      "flag": "TTO",
+      "file": "trinidad_and_tobago.htm",
+      "name": "Trinidad and Tobago",
+      "code": "TT"
+    },
+    "TV": {
+      "flag": "TUV",
+      "file": "tuvalu.htm",
+      "name": "Tuvalu",
+      "code": "TV"
+    },
+    "TW": {
+      "flag": "TWN",
+      "file": "taiwan.htm",
+      "name": "Taiwan, Republic of China",
+      "code": "TW"
+    },
+    "TZ": {
+      "flag": "TZA",
+      "file": "tanzania.htm",
+      "name": "Tanzania, United Republic of",
+      "code": "TZ"
+    },
+    "UA": {
+      "flag": "UKR",
+      "file": "ukraine.htm",
+      "name": "Ukraine",
+      "code": "UA"
+    },
+    "UG": {
+      "flag": "UGA",
+      "file": "uganda.htm",
+      "name": "Uganda",
+      "code": "UG"
+    },
+    "UM": {
+      "flag": "UMI",
+      "file": "",
+      "name": "US Minor Outlying Islands",
+      "code": "UM"
+    },
+    "US": {
+      "flag": "USA",
+      "file": "united_states.htm",
+      "name": "United States of America",
+      "code": "US"
+    },
+    "UY": {
+      "flag": "URY",
+      "file": "uruguay.htm",
+      "name": "Uruguay",
+      "code": "UY"
+    },
+    "UZ": {
+      "flag": "UZB",
+      "file": "uzbekistan.htm",
+      "name": "Uzbekistan",
+      "code": "UZ"
+    },
+    "VA": {
+      "flag": "VAT",
+      "file": "vatican.htm",
+      "name": "Holy See (Vatican City State)",
+      "code": "VA"
+    },
+    "VC": {
+      "flag": "VCT",
+      "file": "saint_vincent_grenadines.htm",
+      "name": "Saint Vincent and Grenadines",
+      "code": "VC"
+    },
+    "VE": {
+      "flag": "VEN",
+      "file": "venezuela.htm",
+      "name": "Venezuela (Bolivarian Republic)",
+      "code": "VE"
+    },
+    "VG": {
+      "flag": "VGB",
+      "file": "virgin_islands_british.htm",
+      "name": "British Virgin Islands",
+      "code": "VG"
+    },
+    "VI": {
+      "flag": "VIR",
+      "file": "virgin_islands_us.htm",
+      "name": "Virgin Islands, US",
+      "code": "VI"
+    },
+    "VN": {
+      "flag": "VNM",
+      "file": "vietnam.htm",
+      "name": "Viet Nam",
+      "code": "VN"
+    },
+    "VU": {
+      "flag": "VUT",
+      "file": "vanuatu.htm",
+      "name": "Vanuatu",
+      "code": "VU"
+    },
+    "WF": {
+      "flag": "WLF",
+      "file": "",
+      "name": "Wallis and Futuna Islands",
+      "code": "WF"
+    },
+    "WS": {
+      "flag": "WSM",
+      "file": "samoa.htm",
+      "name": "Samoa",
+      "code": "WS"
+    },
+    "YE": {
+      "flag": "YEM",
+      "file": "yemen.htm",
+      "name": "Yemen",
+      "code": "YE"
+    },
+    "YT": {
+      "flag": "MYT",
+      "file": "",
+      "name": "Mayotte",
+      "code": "YT"
+    },
+    "ZA": {
+      "flag": "ZAF",
+      "file": "south_africa.htm",
+      "name": "South Africa",
+      "code": "ZA"
+    },
+    "ZM": {
+      "flag": "ZMB",
+      "file": "zambia.htm",
+      "name": "Zambia",
+      "code": "ZM"
+    },
+    "ZW": {
+      "flag": "ZWE",
+      "file": "zimbabwe.htm",
+      "name": "Zimbabwe",
+      "code": "ZW"
+    }
+  }
+}

--- a/src/Resources/LanguageCodes.json
+++ b/src/Resources/LanguageCodes.json
@@ -1,0 +1,24418 @@
+{
+  "Languages": {
+    "aa": {
+      "name": "Afar"
+    },
+    "ab": {
+      "name": "Abkhazian"
+    },
+    "ae": {
+      "name": "Avestan"
+    },
+    "af": {
+      "name": "Afrikaans"
+    },
+    "ak": {
+      "name": "Akan"
+    },
+    "am": {
+      "name": "Amharic"
+    },
+    "an": {
+      "name": "Aragonese"
+    },
+    "ar": {
+      "name": "Arabic"
+    },
+    "as": {
+      "name": "Assamese"
+    },
+    "av": {
+      "name": "Avaric"
+    },
+    "ay": {
+      "name": "Aymara"
+    },
+    "az": {
+      "name": "Azerbaijani"
+    },
+    "ba": {
+      "name": "Bashkir"
+    },
+    "be": {
+      "name": "Belarusian"
+    },
+    "bg": {
+      "name": "Bulgarian"
+    },
+    "bh": {
+      "name": "Bihari languages"
+    },
+    "bi": {
+      "name": "Bislama"
+    },
+    "bm": {
+      "name": "Bambara"
+    },
+    "bn": {
+      "name": "Bengali"
+    },
+    "bo": {
+      "name": "Tibetan"
+    },
+    "br": {
+      "name": "Breton"
+    },
+    "bs": {
+      "name": "Bosnian"
+    },
+    "ca": {
+      "name": "Catalan"
+    },
+    "ce": {
+      "name": "Chechen"
+    },
+    "ch": {
+      "name": "Chamorro"
+    },
+    "co": {
+      "name": "Corsican"
+    },
+    "cr": {
+      "name": "Cree"
+    },
+    "cs": {
+      "name": "Czech"
+    },
+    "cu": {
+      "name": "Church Slavic"
+    },
+    "cv": {
+      "name": "Chuvash"
+    },
+    "cy": {
+      "name": "Welsh"
+    },
+    "da": {
+      "name": "Danish"
+    },
+    "de": {
+      "name": "German"
+    },
+    "dv": {
+      "name": "Dhivehi"
+    },
+    "dz": {
+      "name": "Dzongkha"
+    },
+    "ee": {
+      "name": "Ewe"
+    },
+    "el": {
+      "name": "Modern Greek (1453-)"
+    },
+    "en": {
+      "name": "English"
+    },
+    "eo": {
+      "name": "Esperanto"
+    },
+    "es": {
+      "name": "Spanish"
+    },
+    "et": {
+      "name": "Estonian"
+    },
+    "eu": {
+      "name": "Basque"
+    },
+    "fa": {
+      "name": "Persian"
+    },
+    "ff": {
+      "name": "Fulah"
+    },
+    "fi": {
+      "name": "Finnish"
+    },
+    "fj": {
+      "name": "Fijian"
+    },
+    "fo": {
+      "name": "Faroese"
+    },
+    "fr": {
+      "name": "French"
+    },
+    "fy": {
+      "name": "Western Frisian"
+    },
+    "ga": {
+      "name": "Irish"
+    },
+    "gd": {
+      "name": "Scottish Gaelic"
+    },
+    "gl": {
+      "name": "Galician"
+    },
+    "gn": {
+      "name": "Guarani"
+    },
+    "gu": {
+      "name": "Gujarati"
+    },
+    "gv": {
+      "name": "Manx"
+    },
+    "ha": {
+      "name": "Hausa"
+    },
+    "he": {
+      "name": "Hebrew"
+    },
+    "hi": {
+      "name": "Hindi"
+    },
+    "ho": {
+      "name": "Hiri Motu"
+    },
+    "hr": {
+      "name": "Croatian"
+    },
+    "ht": {
+      "name": "Haitian"
+    },
+    "hu": {
+      "name": "Hungarian"
+    },
+    "hy": {
+      "name": "Armenian"
+    },
+    "hz": {
+      "name": "Herero"
+    },
+    "ia": {
+      "name": "Interlingua (International Auxiliary Language Association)"
+    },
+    "id": {
+      "name": "Indonesian"
+    },
+    "ie": {
+      "name": "Interlingue"
+    },
+    "ig": {
+      "name": "Igbo"
+    },
+    "ii": {
+      "name": "Sichuan Yi"
+    },
+    "ik": {
+      "name": "Inupiaq"
+    },
+    "in": {
+      "name": "Indonesian"
+    },
+    "io": {
+      "name": "Ido"
+    },
+    "is": {
+      "name": "Icelandic"
+    },
+    "it": {
+      "name": "Italian"
+    },
+    "iu": {
+      "name": "Inuktitut"
+    },
+    "iw": {
+      "name": "Hebrew"
+    },
+    "ja": {
+      "name": "Japanese"
+    },
+    "ji": {
+      "name": "Yiddish"
+    },
+    "jv": {
+      "name": "Javanese"
+    },
+    "jw": {
+      "name": "Javanese"
+    },
+    "ka": {
+      "name": "Georgian"
+    },
+    "kg": {
+      "name": "Kongo"
+    },
+    "ki": {
+      "name": "Kikuyu"
+    },
+    "kj": {
+      "name": "Kuanyama"
+    },
+    "kk": {
+      "name": "Kazakh"
+    },
+    "kl": {
+      "name": "Kalaallisut"
+    },
+    "km": {
+      "name": "Khmer"
+    },
+    "kn": {
+      "name": "Kannada"
+    },
+    "ko": {
+      "name": "Korean"
+    },
+    "kr": {
+      "name": "Kanuri"
+    },
+    "ks": {
+      "name": "Kashmiri"
+    },
+    "ku": {
+      "name": "Kurdish"
+    },
+    "kv": {
+      "name": "Komi"
+    },
+    "kw": {
+      "name": "Cornish"
+    },
+    "ky": {
+      "name": "Kirghiz"
+    },
+    "la": {
+      "name": "Latin"
+    },
+    "lb": {
+      "name": "Luxembourgish"
+    },
+    "lg": {
+      "name": "Ganda"
+    },
+    "li": {
+      "name": "Limburgan"
+    },
+    "ln": {
+      "name": "Lingala"
+    },
+    "lo": {
+      "name": "Lao"
+    },
+    "lt": {
+      "name": "Lithuanian"
+    },
+    "lu": {
+      "name": "Luba-Katanga"
+    },
+    "lv": {
+      "name": "Latvian"
+    },
+    "mg": {
+      "name": "Malagasy"
+    },
+    "mh": {
+      "name": "Marshallese"
+    },
+    "mi": {
+      "name": "Maori"
+    },
+    "mk": {
+      "name": "Macedonian"
+    },
+    "ml": {
+      "name": "Malayalam"
+    },
+    "mn": {
+      "name": "Mongolian"
+    },
+    "mo": {
+      "name": "Moldavian"
+    },
+    "mr": {
+      "name": "Marathi"
+    },
+    "ms": {
+      "name": "Malay (macrolanguage)"
+    },
+    "mt": {
+      "name": "Maltese"
+    },
+    "my": {
+      "name": "Burmese"
+    },
+    "na": {
+      "name": "Nauru"
+    },
+    "nb": {
+      "name": "Norwegian Bokmål"
+    },
+    "nd": {
+      "name": "North Ndebele"
+    },
+    "ne": {
+      "name": "Nepali (macrolanguage)"
+    },
+    "ng": {
+      "name": "Ndonga"
+    },
+    "nl": {
+      "name": "Dutch"
+    },
+    "nn": {
+      "name": "Norwegian Nynorsk"
+    },
+    "no": {
+      "name": "Norwegian"
+    },
+    "nr": {
+      "name": "South Ndebele"
+    },
+    "nv": {
+      "name": "Navajo"
+    },
+    "ny": {
+      "name": "Nyanja"
+    },
+    "oc": {
+      "name": "Occitan (post 1500)"
+    },
+    "oj": {
+      "name": "Ojibwa"
+    },
+    "om": {
+      "name": "Oromo"
+    },
+    "or": {
+      "name": "Oriya (macrolanguage)"
+    },
+    "os": {
+      "name": "Ossetian"
+    },
+    "pa": {
+      "name": "Panjabi"
+    },
+    "pi": {
+      "name": "Pali"
+    },
+    "pl": {
+      "name": "Polish"
+    },
+    "ps": {
+      "name": "Pushto"
+    },
+    "pt": {
+      "name": "Portuguese"
+    },
+    "qu": {
+      "name": "Quechua"
+    },
+    "rm": {
+      "name": "Romansh"
+    },
+    "rn": {
+      "name": "Rundi"
+    },
+    "ro": {
+      "name": "Romanian"
+    },
+    "ru": {
+      "name": "Russian"
+    },
+    "rw": {
+      "name": "Kinyarwanda"
+    },
+    "sa": {
+      "name": "Sanskrit"
+    },
+    "sc": {
+      "name": "Sardinian"
+    },
+    "sd": {
+      "name": "Sindhi"
+    },
+    "se": {
+      "name": "Northern Sami"
+    },
+    "sg": {
+      "name": "Sango"
+    },
+    "sh": {
+      "name": "Serbo-Croatian"
+    },
+    "si": {
+      "name": "Sinhala"
+    },
+    "sk": {
+      "name": "Slovak"
+    },
+    "sl": {
+      "name": "Slovenian"
+    },
+    "sm": {
+      "name": "Samoan"
+    },
+    "sn": {
+      "name": "Shona"
+    },
+    "so": {
+      "name": "Somali"
+    },
+    "sq": {
+      "name": "Albanian"
+    },
+    "sr": {
+      "name": "Serbian"
+    },
+    "ss": {
+      "name": "Swati"
+    },
+    "st": {
+      "name": "Southern Sotho"
+    },
+    "su": {
+      "name": "Sundanese"
+    },
+    "sv": {
+      "name": "Swedish"
+    },
+    "sw": {
+      "name": "Swahili (macrolanguage)"
+    },
+    "ta": {
+      "name": "Tamil"
+    },
+    "te": {
+      "name": "Telugu"
+    },
+    "tg": {
+      "name": "Tajik"
+    },
+    "th": {
+      "name": "Thai"
+    },
+    "ti": {
+      "name": "Tigrinya"
+    },
+    "tk": {
+      "name": "Turkmen"
+    },
+    "tl": {
+      "name": "Tagalog"
+    },
+    "tn": {
+      "name": "Tswana"
+    },
+    "to": {
+      "name": "Tonga (Tonga Islands)"
+    },
+    "tr": {
+      "name": "Turkish"
+    },
+    "ts": {
+      "name": "Tsonga"
+    },
+    "tt": {
+      "name": "Tatar"
+    },
+    "tw": {
+      "name": "Twi"
+    },
+    "ty": {
+      "name": "Tahitian"
+    },
+    "ug": {
+      "name": "Uighur"
+    },
+    "uk": {
+      "name": "Ukrainian"
+    },
+    "ur": {
+      "name": "Urdu"
+    },
+    "uz": {
+      "name": "Uzbek"
+    },
+    "ve": {
+      "name": "Venda"
+    },
+    "vi": {
+      "name": "Vietnamese"
+    },
+    "vo": {
+      "name": "Volapük"
+    },
+    "wa": {
+      "name": "Walloon"
+    },
+    "wo": {
+      "name": "Wolof"
+    },
+    "xh": {
+      "name": "Xhosa"
+    },
+    "yi": {
+      "name": "Yiddish"
+    },
+    "yo": {
+      "name": "Yoruba"
+    },
+    "za": {
+      "name": "Zhuang"
+    },
+    "zh": {
+      "name": "Chinese"
+    },
+    "zu": {
+      "name": "Zulu"
+    },
+    "aaa": {
+      "name": "Ghotuo"
+    },
+    "aab": {
+      "name": "Alumu-Tesu"
+    },
+    "aac": {
+      "name": "Ari"
+    },
+    "aad": {
+      "name": "Amal"
+    },
+    "aae": {
+      "name": "Arbëreshë Albanian"
+    },
+    "aaf": {
+      "name": "Aranadan"
+    },
+    "aag": {
+      "name": "Ambrak"
+    },
+    "aah": {
+      "name": "Abu' Arapesh"
+    },
+    "aai": {
+      "name": "Arifama-Miniafia"
+    },
+    "aak": {
+      "name": "Ankave"
+    },
+    "aal": {
+      "name": "Afade"
+    },
+    "aam": {
+      "name": "Aramanik"
+    },
+    "aan": {
+      "name": "Anambé"
+    },
+    "aao": {
+      "name": "Algerian Saharan Arabic"
+    },
+    "aap": {
+      "name": "Pará Arára"
+    },
+    "aaq": {
+      "name": "Eastern Abnaki"
+    },
+    "aas": {
+      "name": "Aasáx"
+    },
+    "aat": {
+      "name": "Arvanitika Albanian"
+    },
+    "aau": {
+      "name": "Abau"
+    },
+    "aav": {
+      "name": "Austro-Asiatic languages"
+    },
+    "aaw": {
+      "name": "Solong"
+    },
+    "aax": {
+      "name": "Mandobo Atas"
+    },
+    "aaz": {
+      "name": "Amarasi"
+    },
+    "aba": {
+      "name": "Abé"
+    },
+    "abb": {
+      "name": "Bankon"
+    },
+    "abc": {
+      "name": "Ambala Ayta"
+    },
+    "abd": {
+      "name": "Manide"
+    },
+    "abe": {
+      "name": "Western Abnaki"
+    },
+    "abf": {
+      "name": "Abai Sungai"
+    },
+    "abg": {
+      "name": "Abaga"
+    },
+    "abh": {
+      "name": "Tajiki Arabic"
+    },
+    "abi": {
+      "name": "Abidji"
+    },
+    "abj": {
+      "name": "Aka-Bea"
+    },
+    "abl": {
+      "name": "Lampung Nyo"
+    },
+    "abm": {
+      "name": "Abanyom"
+    },
+    "abn": {
+      "name": "Abua"
+    },
+    "abo": {
+      "name": "Abon"
+    },
+    "abp": {
+      "name": "Abellen Ayta"
+    },
+    "abq": {
+      "name": "Abaza"
+    },
+    "abr": {
+      "name": "Abron"
+    },
+    "abs": {
+      "name": "Ambonese Malay"
+    },
+    "abt": {
+      "name": "Ambulas"
+    },
+    "abu": {
+      "name": "Abure"
+    },
+    "abv": {
+      "name": "Baharna Arabic"
+    },
+    "abw": {
+      "name": "Pal"
+    },
+    "abx": {
+      "name": "Inabaknon"
+    },
+    "aby": {
+      "name": "Aneme Wake"
+    },
+    "abz": {
+      "name": "Abui"
+    },
+    "aca": {
+      "name": "Achagua"
+    },
+    "acb": {
+      "name": "Áncá"
+    },
+    "acd": {
+      "name": "Gikyode"
+    },
+    "ace": {
+      "name": "Achinese"
+    },
+    "acf": {
+      "name": "Saint Lucian Creole French"
+    },
+    "ach": {
+      "name": "Acoli"
+    },
+    "aci": {
+      "name": "Aka-Cari"
+    },
+    "ack": {
+      "name": "Aka-Kora"
+    },
+    "acl": {
+      "name": "Akar-Bale"
+    },
+    "acm": {
+      "name": "Mesopotamian Arabic"
+    },
+    "acn": {
+      "name": "Achang"
+    },
+    "acp": {
+      "name": "Eastern Acipa"
+    },
+    "acq": {
+      "name": "Ta'izzi-Adeni Arabic"
+    },
+    "acr": {
+      "name": "Achi"
+    },
+    "acs": {
+      "name": "Acroá"
+    },
+    "act": {
+      "name": "Achterhoeks"
+    },
+    "acu": {
+      "name": "Achuar-Shiwiar"
+    },
+    "acv": {
+      "name": "Achumawi"
+    },
+    "acw": {
+      "name": "Hijazi Arabic"
+    },
+    "acx": {
+      "name": "Omani Arabic"
+    },
+    "acy": {
+      "name": "Cypriot Arabic"
+    },
+    "acz": {
+      "name": "Acheron"
+    },
+    "ada": {
+      "name": "Adangme"
+    },
+    "adb": {
+      "name": "Adabe"
+    },
+    "add": {
+      "name": "Lidzonka"
+    },
+    "ade": {
+      "name": "Adele"
+    },
+    "adf": {
+      "name": "Dhofari Arabic"
+    },
+    "adg": {
+      "name": "Andegerebinha"
+    },
+    "adh": {
+      "name": "Adhola"
+    },
+    "adi": {
+      "name": "Adi"
+    },
+    "adj": {
+      "name": "Adioukrou"
+    },
+    "adl": {
+      "name": "Galo"
+    },
+    "adn": {
+      "name": "Adang"
+    },
+    "ado": {
+      "name": "Abu"
+    },
+    "adp": {
+      "name": "Adap"
+    },
+    "adq": {
+      "name": "Adangbe"
+    },
+    "adr": {
+      "name": "Adonara"
+    },
+    "ads": {
+      "name": "Adamorobe Sign Language"
+    },
+    "adt": {
+      "name": "Adnyamathanha"
+    },
+    "adu": {
+      "name": "Aduge"
+    },
+    "adw": {
+      "name": "Amundava"
+    },
+    "adx": {
+      "name": "Amdo Tibetan"
+    },
+    "ady": {
+      "name": "Adyghe"
+    },
+    "adz": {
+      "name": "Adzera"
+    },
+    "aea": {
+      "name": "Areba"
+    },
+    "aeb": {
+      "name": "Tunisian Arabic"
+    },
+    "aec": {
+      "name": "Saidi Arabic"
+    },
+    "aed": {
+      "name": "Argentine Sign Language"
+    },
+    "aee": {
+      "name": "Northeast Pashai"
+    },
+    "aek": {
+      "name": "Haeke"
+    },
+    "ael": {
+      "name": "Ambele"
+    },
+    "aem": {
+      "name": "Arem"
+    },
+    "aen": {
+      "name": "Armenian Sign Language"
+    },
+    "aeq": {
+      "name": "Aer"
+    },
+    "aer": {
+      "name": "Eastern Arrernte"
+    },
+    "aes": {
+      "name": "Alsea"
+    },
+    "aeu": {
+      "name": "Akeu"
+    },
+    "aew": {
+      "name": "Ambakich"
+    },
+    "aey": {
+      "name": "Amele"
+    },
+    "aez": {
+      "name": "Aeka"
+    },
+    "afa": {
+      "name": "Afro-Asiatic languages"
+    },
+    "afb": {
+      "name": "Gulf Arabic"
+    },
+    "afd": {
+      "name": "Andai"
+    },
+    "afe": {
+      "name": "Putukwam"
+    },
+    "afg": {
+      "name": "Afghan Sign Language"
+    },
+    "afh": {
+      "name": "Afrihili"
+    },
+    "afi": {
+      "name": "Akrukay"
+    },
+    "afk": {
+      "name": "Nanubae"
+    },
+    "afn": {
+      "name": "Defaka"
+    },
+    "afo": {
+      "name": "Eloyi"
+    },
+    "afp": {
+      "name": "Tapei"
+    },
+    "afs": {
+      "name": "Afro-Seminole Creole"
+    },
+    "aft": {
+      "name": "Afitti"
+    },
+    "afu": {
+      "name": "Awutu"
+    },
+    "afz": {
+      "name": "Obokuitai"
+    },
+    "aga": {
+      "name": "Aguano"
+    },
+    "agb": {
+      "name": "Legbo"
+    },
+    "agc": {
+      "name": "Agatu"
+    },
+    "agd": {
+      "name": "Agarabi"
+    },
+    "age": {
+      "name": "Angal"
+    },
+    "agf": {
+      "name": "Arguni"
+    },
+    "agg": {
+      "name": "Angor"
+    },
+    "agh": {
+      "name": "Ngelima"
+    },
+    "agi": {
+      "name": "Agariya"
+    },
+    "agj": {
+      "name": "Argobba"
+    },
+    "agk": {
+      "name": "Isarog Agta"
+    },
+    "agl": {
+      "name": "Fembe"
+    },
+    "agm": {
+      "name": "Angaataha"
+    },
+    "agn": {
+      "name": "Agutaynen"
+    },
+    "ago": {
+      "name": "Tainae"
+    },
+    "agp": {
+      "name": "Paranan"
+    },
+    "agq": {
+      "name": "Aghem"
+    },
+    "agr": {
+      "name": "Aguaruna"
+    },
+    "ags": {
+      "name": "Esimbi"
+    },
+    "agt": {
+      "name": "Central Cagayan Agta"
+    },
+    "agu": {
+      "name": "Aguacateco"
+    },
+    "agv": {
+      "name": "Remontado Dumagat"
+    },
+    "agw": {
+      "name": "Kahua"
+    },
+    "agx": {
+      "name": "Aghul"
+    },
+    "agy": {
+      "name": "Southern Alta"
+    },
+    "agz": {
+      "name": "Mt. Iriga Agta"
+    },
+    "aha": {
+      "name": "Ahanta"
+    },
+    "ahb": {
+      "name": "Axamb"
+    },
+    "ahg": {
+      "name": "Qimant"
+    },
+    "ahh": {
+      "name": "Aghu"
+    },
+    "ahi": {
+      "name": "Tiagbamrin Aizi"
+    },
+    "ahk": {
+      "name": "Akha"
+    },
+    "ahl": {
+      "name": "Igo"
+    },
+    "ahm": {
+      "name": "Mobumrin Aizi"
+    },
+    "ahn": {
+      "name": "Àhàn"
+    },
+    "aho": {
+      "name": "Ahom"
+    },
+    "ahp": {
+      "name": "Aproumu Aizi"
+    },
+    "ahr": {
+      "name": "Ahirani"
+    },
+    "ahs": {
+      "name": "Ashe"
+    },
+    "aht": {
+      "name": "Ahtena"
+    },
+    "aia": {
+      "name": "Arosi"
+    },
+    "aib": {
+      "name": "Ainu (China)"
+    },
+    "aic": {
+      "name": "Ainbai"
+    },
+    "aid": {
+      "name": "Alngith"
+    },
+    "aie": {
+      "name": "Amara"
+    },
+    "aif": {
+      "name": "Agi"
+    },
+    "aig": {
+      "name": "Antigua and Barbuda Creole English"
+    },
+    "aih": {
+      "name": "Ai-Cham"
+    },
+    "aii": {
+      "name": "Assyrian Neo-Aramaic"
+    },
+    "aij": {
+      "name": "Lishanid Noshan"
+    },
+    "aik": {
+      "name": "Ake"
+    },
+    "ail": {
+      "name": "Aimele"
+    },
+    "aim": {
+      "name": "Aimol"
+    },
+    "ain": {
+      "name": "Ainu (Japan)"
+    },
+    "aio": {
+      "name": "Aiton"
+    },
+    "aip": {
+      "name": "Burumakok"
+    },
+    "aiq": {
+      "name": "Aimaq"
+    },
+    "air": {
+      "name": "Airoran"
+    },
+    "ais": {
+      "name": "Nataoran Amis"
+    },
+    "ait": {
+      "name": "Arikem"
+    },
+    "aiw": {
+      "name": "Aari"
+    },
+    "aix": {
+      "name": "Aighon"
+    },
+    "aiy": {
+      "name": "Ali"
+    },
+    "aja": {
+      "name": "Aja (South Sudan)"
+    },
+    "ajg": {
+      "name": "Aja (Benin)"
+    },
+    "aji": {
+      "name": "Ajië"
+    },
+    "ajn": {
+      "name": "Andajin"
+    },
+    "ajp": {
+      "name": "South Levantine Arabic"
+    },
+    "ajt": {
+      "name": "Judeo-Tunisian Arabic"
+    },
+    "aju": {
+      "name": "Judeo-Moroccan Arabic"
+    },
+    "ajw": {
+      "name": "Ajawa"
+    },
+    "ajz": {
+      "name": "Amri Karbi"
+    },
+    "akb": {
+      "name": "Batak Angkola"
+    },
+    "akc": {
+      "name": "Mpur"
+    },
+    "akd": {
+      "name": "Ukpet-Ehom"
+    },
+    "ake": {
+      "name": "Akawaio"
+    },
+    "akf": {
+      "name": "Akpa"
+    },
+    "akg": {
+      "name": "Anakalangu"
+    },
+    "akh": {
+      "name": "Angal Heneng"
+    },
+    "aki": {
+      "name": "Aiome"
+    },
+    "akj": {
+      "name": "Aka-Jeru"
+    },
+    "akk": {
+      "name": "Akkadian"
+    },
+    "akl": {
+      "name": "Aklanon"
+    },
+    "akm": {
+      "name": "Aka-Bo"
+    },
+    "ako": {
+      "name": "Akurio"
+    },
+    "akp": {
+      "name": "Siwu"
+    },
+    "akq": {
+      "name": "Ak"
+    },
+    "akr": {
+      "name": "Araki"
+    },
+    "aks": {
+      "name": "Akaselem"
+    },
+    "akt": {
+      "name": "Akolet"
+    },
+    "aku": {
+      "name": "Akum"
+    },
+    "akv": {
+      "name": "Akhvakh"
+    },
+    "akw": {
+      "name": "Akwa"
+    },
+    "akx": {
+      "name": "Aka-Kede"
+    },
+    "aky": {
+      "name": "Aka-Kol"
+    },
+    "akz": {
+      "name": "Alabama"
+    },
+    "ala": {
+      "name": "Alago"
+    },
+    "alc": {
+      "name": "Qawasqar"
+    },
+    "ald": {
+      "name": "Alladian"
+    },
+    "ale": {
+      "name": "Aleut"
+    },
+    "alf": {
+      "name": "Alege"
+    },
+    "alg": {
+      "name": "Algonquian languages"
+    },
+    "alh": {
+      "name": "Alawa"
+    },
+    "ali": {
+      "name": "Amaimon"
+    },
+    "alj": {
+      "name": "Alangan"
+    },
+    "alk": {
+      "name": "Alak"
+    },
+    "all": {
+      "name": "Allar"
+    },
+    "alm": {
+      "name": "Amblong"
+    },
+    "aln": {
+      "name": "Gheg Albanian"
+    },
+    "alo": {
+      "name": "Larike-Wakasihu"
+    },
+    "alp": {
+      "name": "Alune"
+    },
+    "alq": {
+      "name": "Algonquin"
+    },
+    "alr": {
+      "name": "Alutor"
+    },
+    "als": {
+      "name": "Tosk Albanian"
+    },
+    "alt": {
+      "name": "Southern Altai"
+    },
+    "alu": {
+      "name": "'Are'are"
+    },
+    "alv": {
+      "name": "Atlantic-Congo languages"
+    },
+    "alw": {
+      "name": "Alaba-K’abeena"
+    },
+    "alx": {
+      "name": "Amol"
+    },
+    "aly": {
+      "name": "Alyawarr"
+    },
+    "alz": {
+      "name": "Alur"
+    },
+    "ama": {
+      "name": "Amanayé"
+    },
+    "amb": {
+      "name": "Ambo"
+    },
+    "amc": {
+      "name": "Amahuaca"
+    },
+    "ame": {
+      "name": "Yanesha'"
+    },
+    "amf": {
+      "name": "Hamer-Banna"
+    },
+    "amg": {
+      "name": "Amurdak"
+    },
+    "ami": {
+      "name": "Amis"
+    },
+    "amj": {
+      "name": "Amdang"
+    },
+    "amk": {
+      "name": "Ambai"
+    },
+    "aml": {
+      "name": "War-Jaintia"
+    },
+    "amm": {
+      "name": "Ama (Papua New Guinea)"
+    },
+    "amn": {
+      "name": "Amanab"
+    },
+    "amo": {
+      "name": "Amo"
+    },
+    "amp": {
+      "name": "Alamblak"
+    },
+    "amq": {
+      "name": "Amahai"
+    },
+    "amr": {
+      "name": "Amarakaeri"
+    },
+    "ams": {
+      "name": "Southern Amami-Oshima"
+    },
+    "amt": {
+      "name": "Amto"
+    },
+    "amu": {
+      "name": "Guerrero Amuzgo"
+    },
+    "amv": {
+      "name": "Ambelau"
+    },
+    "amw": {
+      "name": "Western Neo-Aramaic"
+    },
+    "amx": {
+      "name": "Anmatyerre"
+    },
+    "amy": {
+      "name": "Ami"
+    },
+    "amz": {
+      "name": "Atampaya"
+    },
+    "ana": {
+      "name": "Andaqui"
+    },
+    "anb": {
+      "name": "Andoa"
+    },
+    "anc": {
+      "name": "Ngas"
+    },
+    "and": {
+      "name": "Ansus"
+    },
+    "ane": {
+      "name": "Xârâcùù"
+    },
+    "anf": {
+      "name": "Animere"
+    },
+    "ang": {
+      "name": "Old English (ca. 450-1100)"
+    },
+    "anh": {
+      "name": "Nend"
+    },
+    "ani": {
+      "name": "Andi"
+    },
+    "anj": {
+      "name": "Anor"
+    },
+    "ank": {
+      "name": "Goemai"
+    },
+    "anl": {
+      "name": "Anu-Hkongso Chin"
+    },
+    "anm": {
+      "name": "Anal"
+    },
+    "ann": {
+      "name": "Obolo"
+    },
+    "ano": {
+      "name": "Andoque"
+    },
+    "anp": {
+      "name": "Angika"
+    },
+    "anq": {
+      "name": "Jarawa (India)"
+    },
+    "anr": {
+      "name": "Andh"
+    },
+    "ans": {
+      "name": "Anserma"
+    },
+    "ant": {
+      "name": "Antakarinya"
+    },
+    "anu": {
+      "name": "Anuak"
+    },
+    "anv": {
+      "name": "Denya"
+    },
+    "anw": {
+      "name": "Anaang"
+    },
+    "anx": {
+      "name": "Andra-Hus"
+    },
+    "any": {
+      "name": "Anyin"
+    },
+    "anz": {
+      "name": "Anem"
+    },
+    "aoa": {
+      "name": "Angolar"
+    },
+    "aob": {
+      "name": "Abom"
+    },
+    "aoc": {
+      "name": "Pemon"
+    },
+    "aod": {
+      "name": "Andarum"
+    },
+    "aoe": {
+      "name": "Angal Enen"
+    },
+    "aof": {
+      "name": "Bragat"
+    },
+    "aog": {
+      "name": "Angoram"
+    },
+    "aoh": {
+      "name": "Arma"
+    },
+    "aoi": {
+      "name": "Anindilyakwa"
+    },
+    "aoj": {
+      "name": "Mufian"
+    },
+    "aok": {
+      "name": "Arhö"
+    },
+    "aol": {
+      "name": "Alor"
+    },
+    "aom": {
+      "name": "Ömie"
+    },
+    "aon": {
+      "name": "Bumbita Arapesh"
+    },
+    "aor": {
+      "name": "Aore"
+    },
+    "aos": {
+      "name": "Taikat"
+    },
+    "aot": {
+      "name": "Atong (India)"
+    },
+    "aou": {
+      "name": "A'ou"
+    },
+    "aox": {
+      "name": "Atorada"
+    },
+    "aoz": {
+      "name": "Uab Meto"
+    },
+    "apa": {
+      "name": "Apache languages"
+    },
+    "apb": {
+      "name": "Sa'a"
+    },
+    "apc": {
+      "name": "North Levantine Arabic"
+    },
+    "apd": {
+      "name": "Sudanese Arabic"
+    },
+    "ape": {
+      "name": "Bukiyip"
+    },
+    "apf": {
+      "name": "Pahanan Agta"
+    },
+    "apg": {
+      "name": "Ampanang"
+    },
+    "aph": {
+      "name": "Athpariya"
+    },
+    "api": {
+      "name": "Apiaká"
+    },
+    "apj": {
+      "name": "Jicarilla Apache"
+    },
+    "apk": {
+      "name": "Kiowa Apache"
+    },
+    "apl": {
+      "name": "Lipan Apache"
+    },
+    "apm": {
+      "name": "Mescalero-Chiricahua Apache"
+    },
+    "apn": {
+      "name": "Apinayé"
+    },
+    "apo": {
+      "name": "Ambul"
+    },
+    "app": {
+      "name": "Apma"
+    },
+    "apq": {
+      "name": "A-Pucikwar"
+    },
+    "apr": {
+      "name": "Arop-Lokep"
+    },
+    "aps": {
+      "name": "Arop-Sissano"
+    },
+    "apt": {
+      "name": "Apatani"
+    },
+    "apu": {
+      "name": "Apurinã"
+    },
+    "apv": {
+      "name": "Alapmunte"
+    },
+    "apw": {
+      "name": "Western Apache"
+    },
+    "apx": {
+      "name": "Aputai"
+    },
+    "apy": {
+      "name": "Apalaí"
+    },
+    "apz": {
+      "name": "Safeyoka"
+    },
+    "aqa": {
+      "name": "Alacalufan languages"
+    },
+    "aqc": {
+      "name": "Archi"
+    },
+    "aqd": {
+      "name": "Ampari Dogon"
+    },
+    "aqg": {
+      "name": "Arigidi"
+    },
+    "aql": {
+      "name": "Algic languages"
+    },
+    "aqm": {
+      "name": "Atohwaim"
+    },
+    "aqn": {
+      "name": "Northern Alta"
+    },
+    "aqp": {
+      "name": "Atakapa"
+    },
+    "aqr": {
+      "name": "Arhâ"
+    },
+    "aqt": {
+      "name": "Angaité"
+    },
+    "aqz": {
+      "name": "Akuntsu"
+    },
+    "arb": {
+      "name": "Standard Arabic"
+    },
+    "arc": {
+      "name": "Official Aramaic (700-300 BCE)"
+    },
+    "ard": {
+      "name": "Arabana"
+    },
+    "are": {
+      "name": "Western Arrarnta"
+    },
+    "arh": {
+      "name": "Arhuaco"
+    },
+    "ari": {
+      "name": "Arikara"
+    },
+    "arj": {
+      "name": "Arapaso"
+    },
+    "ark": {
+      "name": "Arikapú"
+    },
+    "arl": {
+      "name": "Arabela"
+    },
+    "arn": {
+      "name": "Mapudungun"
+    },
+    "aro": {
+      "name": "Araona"
+    },
+    "arp": {
+      "name": "Arapaho"
+    },
+    "arq": {
+      "name": "Algerian Arabic"
+    },
+    "arr": {
+      "name": "Karo (Brazil)"
+    },
+    "ars": {
+      "name": "Najdi Arabic"
+    },
+    "art": {
+      "name": "Artificial languages"
+    },
+    "aru": {
+      "name": "Aruá (Amazonas State)"
+    },
+    "arv": {
+      "name": "Arbore"
+    },
+    "arw": {
+      "name": "Arawak"
+    },
+    "arx": {
+      "name": "Aruá (Rodonia State)"
+    },
+    "ary": {
+      "name": "Moroccan Arabic"
+    },
+    "arz": {
+      "name": "Egyptian Arabic"
+    },
+    "asa": {
+      "name": "Asu (Tanzania)"
+    },
+    "asb": {
+      "name": "Assiniboine"
+    },
+    "asc": {
+      "name": "Casuarina Coast Asmat"
+    },
+    "asd": {
+      "name": "Asas"
+    },
+    "ase": {
+      "name": "American Sign Language"
+    },
+    "asf": {
+      "name": "Auslan"
+    },
+    "asg": {
+      "name": "Cishingini"
+    },
+    "ash": {
+      "name": "Abishira"
+    },
+    "asi": {
+      "name": "Buruwai"
+    },
+    "asj": {
+      "name": "Sari"
+    },
+    "ask": {
+      "name": "Ashkun"
+    },
+    "asl": {
+      "name": "Asilulu"
+    },
+    "asn": {
+      "name": "Xingú Asuriní"
+    },
+    "aso": {
+      "name": "Dano"
+    },
+    "asp": {
+      "name": "Algerian Sign Language"
+    },
+    "asq": {
+      "name": "Austrian Sign Language"
+    },
+    "asr": {
+      "name": "Asuri"
+    },
+    "ass": {
+      "name": "Ipulo"
+    },
+    "ast": {
+      "name": "Asturian"
+    },
+    "asu": {
+      "name": "Tocantins Asurini"
+    },
+    "asv": {
+      "name": "Asoa"
+    },
+    "asw": {
+      "name": "Australian Aborigines Sign Language"
+    },
+    "asx": {
+      "name": "Muratayak"
+    },
+    "asy": {
+      "name": "Yaosakor Asmat"
+    },
+    "asz": {
+      "name": "As"
+    },
+    "ata": {
+      "name": "Pele-Ata"
+    },
+    "atb": {
+      "name": "Zaiwa"
+    },
+    "atc": {
+      "name": "Atsahuaca"
+    },
+    "atd": {
+      "name": "Ata Manobo"
+    },
+    "ate": {
+      "name": "Atemble"
+    },
+    "atg": {
+      "name": "Ivbie North-Okpela-Arhe"
+    },
+    "ath": {
+      "name": "Athapascan languages"
+    },
+    "ati": {
+      "name": "Attié"
+    },
+    "atj": {
+      "name": "Atikamekw"
+    },
+    "atk": {
+      "name": "Ati"
+    },
+    "atl": {
+      "name": "Mt. Iraya Agta"
+    },
+    "atm": {
+      "name": "Ata"
+    },
+    "atn": {
+      "name": "Ashtiani"
+    },
+    "ato": {
+      "name": "Atong (Cameroon)"
+    },
+    "atp": {
+      "name": "Pudtol Atta"
+    },
+    "atq": {
+      "name": "Aralle-Tabulahan"
+    },
+    "atr": {
+      "name": "Waimiri-Atroari"
+    },
+    "ats": {
+      "name": "Gros Ventre"
+    },
+    "att": {
+      "name": "Pamplona Atta"
+    },
+    "atu": {
+      "name": "Reel"
+    },
+    "atv": {
+      "name": "Northern Altai"
+    },
+    "atw": {
+      "name": "Atsugewi"
+    },
+    "atx": {
+      "name": "Arutani"
+    },
+    "aty": {
+      "name": "Aneityum"
+    },
+    "atz": {
+      "name": "Arta"
+    },
+    "aua": {
+      "name": "Asumboa"
+    },
+    "aub": {
+      "name": "Alugu"
+    },
+    "auc": {
+      "name": "Waorani"
+    },
+    "aud": {
+      "name": "Anuta"
+    },
+    "aue": {
+      "name": "=/Kx'au//'ein"
+    },
+    "auf": {
+      "name": "Arauan languages"
+    },
+    "aug": {
+      "name": "Aguna"
+    },
+    "auh": {
+      "name": "Aushi"
+    },
+    "aui": {
+      "name": "Anuki"
+    },
+    "auj": {
+      "name": "Awjilah"
+    },
+    "auk": {
+      "name": "Heyo"
+    },
+    "aul": {
+      "name": "Aulua"
+    },
+    "aum": {
+      "name": "Asu (Nigeria)"
+    },
+    "aun": {
+      "name": "Molmo One"
+    },
+    "auo": {
+      "name": "Auyokawa"
+    },
+    "aup": {
+      "name": "Makayam"
+    },
+    "auq": {
+      "name": "Anus"
+    },
+    "aur": {
+      "name": "Aruek"
+    },
+    "aus": {
+      "name": "Australian languages"
+    },
+    "aut": {
+      "name": "Austral"
+    },
+    "auu": {
+      "name": "Auye"
+    },
+    "auw": {
+      "name": "Awyi"
+    },
+    "aux": {
+      "name": "Aurá"
+    },
+    "auy": {
+      "name": "Awiyaana"
+    },
+    "auz": {
+      "name": "Uzbeki Arabic"
+    },
+    "avb": {
+      "name": "Avau"
+    },
+    "avd": {
+      "name": "Alviri-Vidari"
+    },
+    "avi": {
+      "name": "Avikam"
+    },
+    "avk": {
+      "name": "Kotava"
+    },
+    "avl": {
+      "name": "Eastern Egyptian Bedawi Arabic"
+    },
+    "avm": {
+      "name": "Angkamuthi"
+    },
+    "avn": {
+      "name": "Avatime"
+    },
+    "avo": {
+      "name": "Agavotaguerra"
+    },
+    "avs": {
+      "name": "Aushiri"
+    },
+    "avt": {
+      "name": "Au"
+    },
+    "avu": {
+      "name": "Avokaya"
+    },
+    "avv": {
+      "name": "Avá-Canoeiro"
+    },
+    "awa": {
+      "name": "Awadhi"
+    },
+    "awb": {
+      "name": "Awa (Papua New Guinea)"
+    },
+    "awc": {
+      "name": "Cicipu"
+    },
+    "awd": {
+      "name": "Arawakan languages"
+    },
+    "awe": {
+      "name": "Awetí"
+    },
+    "awg": {
+      "name": "Anguthimri"
+    },
+    "awh": {
+      "name": "Awbono"
+    },
+    "awi": {
+      "name": "Aekyom"
+    },
+    "awk": {
+      "name": "Awabakal"
+    },
+    "awm": {
+      "name": "Arawum"
+    },
+    "awn": {
+      "name": "Awngi"
+    },
+    "awo": {
+      "name": "Awak"
+    },
+    "awr": {
+      "name": "Awera"
+    },
+    "aws": {
+      "name": "South Awyu"
+    },
+    "awt": {
+      "name": "Araweté"
+    },
+    "awu": {
+      "name": "Central Awyu"
+    },
+    "awv": {
+      "name": "Jair Awyu"
+    },
+    "aww": {
+      "name": "Awun"
+    },
+    "awx": {
+      "name": "Awara"
+    },
+    "awy": {
+      "name": "Edera Awyu"
+    },
+    "axb": {
+      "name": "Abipon"
+    },
+    "axe": {
+      "name": "Ayerrerenge"
+    },
+    "axg": {
+      "name": "Mato Grosso Arára"
+    },
+    "axk": {
+      "name": "Yaka (Central African Republic)"
+    },
+    "axl": {
+      "name": "Lower Southern Aranda"
+    },
+    "axm": {
+      "name": "Middle Armenian"
+    },
+    "axx": {
+      "name": "Xârâgurè"
+    },
+    "aya": {
+      "name": "Awar"
+    },
+    "ayb": {
+      "name": "Ayizo Gbe"
+    },
+    "ayc": {
+      "name": "Southern Aymara"
+    },
+    "ayd": {
+      "name": "Ayabadhu"
+    },
+    "aye": {
+      "name": "Ayere"
+    },
+    "ayg": {
+      "name": "Ginyanga"
+    },
+    "ayh": {
+      "name": "Hadrami Arabic"
+    },
+    "ayi": {
+      "name": "Leyigha"
+    },
+    "ayk": {
+      "name": "Akuku"
+    },
+    "ayl": {
+      "name": "Libyan Arabic"
+    },
+    "ayn": {
+      "name": "Sanaani Arabic"
+    },
+    "ayo": {
+      "name": "Ayoreo"
+    },
+    "ayp": {
+      "name": "North Mesopotamian Arabic"
+    },
+    "ayq": {
+      "name": "Ayi (Papua New Guinea)"
+    },
+    "ayr": {
+      "name": "Central Aymara"
+    },
+    "ays": {
+      "name": "Sorsogon Ayta"
+    },
+    "ayt": {
+      "name": "Magbukun Ayta"
+    },
+    "ayu": {
+      "name": "Ayu"
+    },
+    "ayx": {
+      "name": "Ayi (China)"
+    },
+    "ayy": {
+      "name": "Tayabas Ayta"
+    },
+    "ayz": {
+      "name": "Mai Brat"
+    },
+    "aza": {
+      "name": "Azha"
+    },
+    "azb": {
+      "name": "South Azerbaijani"
+    },
+    "azc": {
+      "name": "Uto-Aztecan languages"
+    },
+    "azd": {
+      "name": "Eastern Durango Nahuatl"
+    },
+    "azg": {
+      "name": "San Pedro Amuzgos Amuzgo"
+    },
+    "azj": {
+      "name": "North Azerbaijani"
+    },
+    "azm": {
+      "name": "Ipalapa Amuzgo"
+    },
+    "azn": {
+      "name": "Western Durango Nahuatl"
+    },
+    "azo": {
+      "name": "Awing"
+    },
+    "azt": {
+      "name": "Faire Atta"
+    },
+    "azz": {
+      "name": "Highland Puebla Nahuatl"
+    },
+    "baa": {
+      "name": "Babatana"
+    },
+    "bab": {
+      "name": "Bainouk-Gunyuño"
+    },
+    "bac": {
+      "name": "Badui"
+    },
+    "bad": {
+      "name": "Banda languages"
+    },
+    "bae": {
+      "name": "Baré"
+    },
+    "baf": {
+      "name": "Nubaca"
+    },
+    "bag": {
+      "name": "Tuki"
+    },
+    "bah": {
+      "name": "Bahamas Creole English"
+    },
+    "bai": {
+      "name": "Bamileke languages"
+    },
+    "baj": {
+      "name": "Barakai"
+    },
+    "bal": {
+      "name": "Baluchi"
+    },
+    "ban": {
+      "name": "Balinese"
+    },
+    "bao": {
+      "name": "Waimaha"
+    },
+    "bap": {
+      "name": "Bantawa"
+    },
+    "bar": {
+      "name": "Bavarian"
+    },
+    "bas": {
+      "name": "Basa (Cameroon)"
+    },
+    "bat": {
+      "name": "Baltic languages"
+    },
+    "bau": {
+      "name": "Bada (Nigeria)"
+    },
+    "bav": {
+      "name": "Vengo"
+    },
+    "baw": {
+      "name": "Bambili-Bambui"
+    },
+    "bax": {
+      "name": "Bamun"
+    },
+    "bay": {
+      "name": "Batuley"
+    },
+    "baz": {
+      "name": "Tunen"
+    },
+    "bba": {
+      "name": "Baatonum"
+    },
+    "bbb": {
+      "name": "Barai"
+    },
+    "bbc": {
+      "name": "Batak Toba"
+    },
+    "bbd": {
+      "name": "Bau"
+    },
+    "bbe": {
+      "name": "Bangba"
+    },
+    "bbf": {
+      "name": "Baibai"
+    },
+    "bbg": {
+      "name": "Barama"
+    },
+    "bbh": {
+      "name": "Bugan"
+    },
+    "bbi": {
+      "name": "Barombi"
+    },
+    "bbj": {
+      "name": "Ghomálá'"
+    },
+    "bbk": {
+      "name": "Babanki"
+    },
+    "bbl": {
+      "name": "Bats"
+    },
+    "bbm": {
+      "name": "Babango"
+    },
+    "bbn": {
+      "name": "Uneapa"
+    },
+    "bbo": {
+      "name": "Northern Bobo Madaré"
+    },
+    "bbp": {
+      "name": "West Central Banda"
+    },
+    "bbq": {
+      "name": "Bamali"
+    },
+    "bbr": {
+      "name": "Girawa"
+    },
+    "bbs": {
+      "name": "Bakpinka"
+    },
+    "bbt": {
+      "name": "Mburku"
+    },
+    "bbu": {
+      "name": "Kulung (Nigeria)"
+    },
+    "bbv": {
+      "name": "Karnai"
+    },
+    "bbw": {
+      "name": "Baba"
+    },
+    "bbx": {
+      "name": "Bubia"
+    },
+    "bby": {
+      "name": "Befang"
+    },
+    "bbz": {
+      "name": "Babalia Creole Arabic"
+    },
+    "bca": {
+      "name": "Central Bai"
+    },
+    "bcb": {
+      "name": "Bainouk-Samik"
+    },
+    "bcc": {
+      "name": "Southern Balochi"
+    },
+    "bcd": {
+      "name": "North Babar"
+    },
+    "bce": {
+      "name": "Bamenyam"
+    },
+    "bcf": {
+      "name": "Bamu"
+    },
+    "bcg": {
+      "name": "Baga Pokur"
+    },
+    "bch": {
+      "name": "Bariai"
+    },
+    "bci": {
+      "name": "Baoulé"
+    },
+    "bcj": {
+      "name": "Bardi"
+    },
+    "bck": {
+      "name": "Bunaba"
+    },
+    "bcl": {
+      "name": "Central Bikol"
+    },
+    "bcm": {
+      "name": "Bannoni"
+    },
+    "bcn": {
+      "name": "Bali (Nigeria)"
+    },
+    "bco": {
+      "name": "Kaluli"
+    },
+    "bcp": {
+      "name": "Bali (Democratic Republic of Congo)"
+    },
+    "bcq": {
+      "name": "Bench"
+    },
+    "bcr": {
+      "name": "Babine"
+    },
+    "bcs": {
+      "name": "Kohumono"
+    },
+    "bct": {
+      "name": "Bendi"
+    },
+    "bcu": {
+      "name": "Awad Bing"
+    },
+    "bcv": {
+      "name": "Shoo-Minda-Nye"
+    },
+    "bcw": {
+      "name": "Bana"
+    },
+    "bcy": {
+      "name": "Bacama"
+    },
+    "bcz": {
+      "name": "Bainouk-Gunyaamolo"
+    },
+    "bda": {
+      "name": "Bayot"
+    },
+    "bdb": {
+      "name": "Basap"
+    },
+    "bdc": {
+      "name": "Emberá-Baudó"
+    },
+    "bdd": {
+      "name": "Bunama"
+    },
+    "bde": {
+      "name": "Bade"
+    },
+    "bdf": {
+      "name": "Biage"
+    },
+    "bdg": {
+      "name": "Bonggi"
+    },
+    "bdh": {
+      "name": "Baka (South Sudan)"
+    },
+    "bdi": {
+      "name": "Burun"
+    },
+    "bdj": {
+      "name": "Bai (South Sudan)"
+    },
+    "bdk": {
+      "name": "Budukh"
+    },
+    "bdl": {
+      "name": "Indonesian Bajau"
+    },
+    "bdm": {
+      "name": "Buduma"
+    },
+    "bdn": {
+      "name": "Baldemu"
+    },
+    "bdo": {
+      "name": "Morom"
+    },
+    "bdp": {
+      "name": "Bende"
+    },
+    "bdq": {
+      "name": "Bahnar"
+    },
+    "bdr": {
+      "name": "West Coast Bajau"
+    },
+    "bds": {
+      "name": "Burunge"
+    },
+    "bdt": {
+      "name": "Bokoto"
+    },
+    "bdu": {
+      "name": "Oroko"
+    },
+    "bdv": {
+      "name": "Bodo Parja"
+    },
+    "bdw": {
+      "name": "Baham"
+    },
+    "bdx": {
+      "name": "Budong-Budong"
+    },
+    "bdy": {
+      "name": "Bandjalang"
+    },
+    "bdz": {
+      "name": "Badeshi"
+    },
+    "bea": {
+      "name": "Beaver"
+    },
+    "beb": {
+      "name": "Bebele"
+    },
+    "bec": {
+      "name": "Iceve-Maci"
+    },
+    "bed": {
+      "name": "Bedoanas"
+    },
+    "bee": {
+      "name": "Byangsi"
+    },
+    "bef": {
+      "name": "Benabena"
+    },
+    "beg": {
+      "name": "Belait"
+    },
+    "beh": {
+      "name": "Biali"
+    },
+    "bei": {
+      "name": "Bekati'"
+    },
+    "bej": {
+      "name": "Beja"
+    },
+    "bek": {
+      "name": "Bebeli"
+    },
+    "bem": {
+      "name": "Bemba (Zambia)"
+    },
+    "beo": {
+      "name": "Beami"
+    },
+    "bep": {
+      "name": "Besoa"
+    },
+    "beq": {
+      "name": "Beembe"
+    },
+    "ber": {
+      "name": "Berber languages"
+    },
+    "bes": {
+      "name": "Besme"
+    },
+    "bet": {
+      "name": "Guiberoua Béte"
+    },
+    "beu": {
+      "name": "Blagar"
+    },
+    "bev": {
+      "name": "Daloa Bété"
+    },
+    "bew": {
+      "name": "Betawi"
+    },
+    "bex": {
+      "name": "Jur Modo"
+    },
+    "bey": {
+      "name": "Beli (Papua New Guinea)"
+    },
+    "bez": {
+      "name": "Bena (Tanzania)"
+    },
+    "bfa": {
+      "name": "Bari"
+    },
+    "bfb": {
+      "name": "Pauri Bareli"
+    },
+    "bfc": {
+      "name": "Panyi Bai"
+    },
+    "bfd": {
+      "name": "Bafut"
+    },
+    "bfe": {
+      "name": "Betaf"
+    },
+    "bff": {
+      "name": "Bofi"
+    },
+    "bfg": {
+      "name": "Busang Kayan"
+    },
+    "bfh": {
+      "name": "Blafe"
+    },
+    "bfi": {
+      "name": "British Sign Language"
+    },
+    "bfj": {
+      "name": "Bafanji"
+    },
+    "bfk": {
+      "name": "Ban Khor Sign Language"
+    },
+    "bfl": {
+      "name": "Banda-Ndélé"
+    },
+    "bfm": {
+      "name": "Mmen"
+    },
+    "bfn": {
+      "name": "Bunak"
+    },
+    "bfo": {
+      "name": "Malba Birifor"
+    },
+    "bfp": {
+      "name": "Beba"
+    },
+    "bfq": {
+      "name": "Badaga"
+    },
+    "bfr": {
+      "name": "Bazigar"
+    },
+    "bfs": {
+      "name": "Southern Bai"
+    },
+    "bft": {
+      "name": "Balti"
+    },
+    "bfu": {
+      "name": "Gahri"
+    },
+    "bfw": {
+      "name": "Bondo"
+    },
+    "bfx": {
+      "name": "Bantayanon"
+    },
+    "bfy": {
+      "name": "Bagheli"
+    },
+    "bfz": {
+      "name": "Mahasu Pahari"
+    },
+    "bga": {
+      "name": "Gwamhi-Wuri"
+    },
+    "bgb": {
+      "name": "Bobongko"
+    },
+    "bgc": {
+      "name": "Haryanvi"
+    },
+    "bgd": {
+      "name": "Rathwi Bareli"
+    },
+    "bge": {
+      "name": "Bauria"
+    },
+    "bgf": {
+      "name": "Bangandu"
+    },
+    "bgg": {
+      "name": "Bugun"
+    },
+    "bgi": {
+      "name": "Giangan"
+    },
+    "bgj": {
+      "name": "Bangolan"
+    },
+    "bgk": {
+      "name": "Bit"
+    },
+    "bgl": {
+      "name": "Bo (Laos)"
+    },
+    "bgm": {
+      "name": "Baga Mboteni"
+    },
+    "bgn": {
+      "name": "Western Balochi"
+    },
+    "bgo": {
+      "name": "Baga Koga"
+    },
+    "bgp": {
+      "name": "Eastern Balochi"
+    },
+    "bgq": {
+      "name": "Bagri"
+    },
+    "bgr": {
+      "name": "Bawm Chin"
+    },
+    "bgs": {
+      "name": "Tagabawa"
+    },
+    "bgt": {
+      "name": "Bughotu"
+    },
+    "bgu": {
+      "name": "Mbongno"
+    },
+    "bgv": {
+      "name": "Warkay-Bipim"
+    },
+    "bgw": {
+      "name": "Bhatri"
+    },
+    "bgx": {
+      "name": "Balkan Gagauz Turkish"
+    },
+    "bgy": {
+      "name": "Benggoi"
+    },
+    "bgz": {
+      "name": "Banggai"
+    },
+    "bha": {
+      "name": "Bharia"
+    },
+    "bhb": {
+      "name": "Bhili"
+    },
+    "bhc": {
+      "name": "Biga"
+    },
+    "bhd": {
+      "name": "Bhadrawahi"
+    },
+    "bhe": {
+      "name": "Bhaya"
+    },
+    "bhf": {
+      "name": "Odiai"
+    },
+    "bhg": {
+      "name": "Binandere"
+    },
+    "bhh": {
+      "name": "Bukharic"
+    },
+    "bhi": {
+      "name": "Bhilali"
+    },
+    "bhj": {
+      "name": "Bahing"
+    },
+    "bhk": {
+      "name": "Albay Bicolano"
+    },
+    "bhl": {
+      "name": "Bimin"
+    },
+    "bhm": {
+      "name": "Bathari"
+    },
+    "bhn": {
+      "name": "Bohtan Neo-Aramaic"
+    },
+    "bho": {
+      "name": "Bhojpuri"
+    },
+    "bhp": {
+      "name": "Bima"
+    },
+    "bhq": {
+      "name": "Tukang Besi South"
+    },
+    "bhr": {
+      "name": "Bara Malagasy"
+    },
+    "bhs": {
+      "name": "Buwal"
+    },
+    "bht": {
+      "name": "Bhattiyali"
+    },
+    "bhu": {
+      "name": "Bhunjia"
+    },
+    "bhv": {
+      "name": "Bahau"
+    },
+    "bhw": {
+      "name": "Biak"
+    },
+    "bhx": {
+      "name": "Bhalay"
+    },
+    "bhy": {
+      "name": "Bhele"
+    },
+    "bhz": {
+      "name": "Bada (Indonesia)"
+    },
+    "bia": {
+      "name": "Badimaya"
+    },
+    "bib": {
+      "name": "Bissa"
+    },
+    "bic": {
+      "name": "Bikaru"
+    },
+    "bid": {
+      "name": "Bidiyo"
+    },
+    "bie": {
+      "name": "Bepour"
+    },
+    "bif": {
+      "name": "Biafada"
+    },
+    "big": {
+      "name": "Biangai"
+    },
+    "bij": {
+      "name": "Vaghat-Ya-Bijim-Legeri"
+    },
+    "bik": {
+      "name": "Bikol"
+    },
+    "bil": {
+      "name": "Bile"
+    },
+    "bim": {
+      "name": "Bimoba"
+    },
+    "bin": {
+      "name": "Bini"
+    },
+    "bio": {
+      "name": "Nai"
+    },
+    "bip": {
+      "name": "Bila"
+    },
+    "biq": {
+      "name": "Bipi"
+    },
+    "bir": {
+      "name": "Bisorio"
+    },
+    "bit": {
+      "name": "Berinomo"
+    },
+    "biu": {
+      "name": "Biete"
+    },
+    "biv": {
+      "name": "Southern Birifor"
+    },
+    "biw": {
+      "name": "Kol (Cameroon)"
+    },
+    "bix": {
+      "name": "Bijori"
+    },
+    "biy": {
+      "name": "Birhor"
+    },
+    "biz": {
+      "name": "Baloi"
+    },
+    "bja": {
+      "name": "Budza"
+    },
+    "bjb": {
+      "name": "Banggarla"
+    },
+    "bjc": {
+      "name": "Bariji"
+    },
+    "bjd": {
+      "name": "Bandjigali"
+    },
+    "bje": {
+      "name": "Biao-Jiao Mien"
+    },
+    "bjf": {
+      "name": "Barzani Jewish Neo-Aramaic"
+    },
+    "bjg": {
+      "name": "Bidyogo"
+    },
+    "bjh": {
+      "name": "Bahinemo"
+    },
+    "bji": {
+      "name": "Burji"
+    },
+    "bjj": {
+      "name": "Kanauji"
+    },
+    "bjk": {
+      "name": "Barok"
+    },
+    "bjl": {
+      "name": "Bulu (Papua New Guinea)"
+    },
+    "bjm": {
+      "name": "Bajelani"
+    },
+    "bjn": {
+      "name": "Banjar"
+    },
+    "bjo": {
+      "name": "Mid-Southern Banda"
+    },
+    "bjp": {
+      "name": "Fanamaket"
+    },
+    "bjq": {
+      "name": "Southern Betsimisaraka Malagasy"
+    },
+    "bjr": {
+      "name": "Binumarien"
+    },
+    "bjs": {
+      "name": "Bajan"
+    },
+    "bjt": {
+      "name": "Balanta-Ganja"
+    },
+    "bju": {
+      "name": "Busuu"
+    },
+    "bjv": {
+      "name": "Bedjond"
+    },
+    "bjw": {
+      "name": "Bakwé"
+    },
+    "bjx": {
+      "name": "Banao Itneg"
+    },
+    "bjy": {
+      "name": "Bayali"
+    },
+    "bjz": {
+      "name": "Baruga"
+    },
+    "bka": {
+      "name": "Kyak"
+    },
+    "bkb": {
+      "name": "Finallig"
+    },
+    "bkc": {
+      "name": "Baka (Cameroon)"
+    },
+    "bkd": {
+      "name": "Binukid"
+    },
+    "bkf": {
+      "name": "Beeke"
+    },
+    "bkg": {
+      "name": "Buraka"
+    },
+    "bkh": {
+      "name": "Bakoko"
+    },
+    "bki": {
+      "name": "Baki"
+    },
+    "bkj": {
+      "name": "Pande"
+    },
+    "bkk": {
+      "name": "Brokskat"
+    },
+    "bkl": {
+      "name": "Berik"
+    },
+    "bkm": {
+      "name": "Kom (Cameroon)"
+    },
+    "bkn": {
+      "name": "Bukitan"
+    },
+    "bko": {
+      "name": "Kwa'"
+    },
+    "bkp": {
+      "name": "Boko (Democratic Republic of Congo)"
+    },
+    "bkq": {
+      "name": "Bakairí"
+    },
+    "bkr": {
+      "name": "Bakumpai"
+    },
+    "bks": {
+      "name": "Northern Sorsoganon"
+    },
+    "bkt": {
+      "name": "Boloki"
+    },
+    "bku": {
+      "name": "Buhid"
+    },
+    "bkv": {
+      "name": "Bekwarra"
+    },
+    "bkw": {
+      "name": "Bekwel"
+    },
+    "bkx": {
+      "name": "Baikeno"
+    },
+    "bky": {
+      "name": "Bokyi"
+    },
+    "bkz": {
+      "name": "Bungku"
+    },
+    "bla": {
+      "name": "Siksika"
+    },
+    "blb": {
+      "name": "Bilua"
+    },
+    "blc": {
+      "name": "Bella Coola"
+    },
+    "bld": {
+      "name": "Bolango"
+    },
+    "ble": {
+      "name": "Balanta-Kentohe"
+    },
+    "blf": {
+      "name": "Buol"
+    },
+    "blg": {
+      "name": "Balau"
+    },
+    "blh": {
+      "name": "Kuwaa"
+    },
+    "bli": {
+      "name": "Bolia"
+    },
+    "blj": {
+      "name": "Bolongan"
+    },
+    "blk": {
+      "name": "Pa'o Karen"
+    },
+    "bll": {
+      "name": "Biloxi"
+    },
+    "blm": {
+      "name": "Beli (South Sudan)"
+    },
+    "bln": {
+      "name": "Southern Catanduanes Bikol"
+    },
+    "blo": {
+      "name": "Anii"
+    },
+    "blp": {
+      "name": "Blablanga"
+    },
+    "blq": {
+      "name": "Baluan-Pam"
+    },
+    "blr": {
+      "name": "Blang"
+    },
+    "bls": {
+      "name": "Balaesang"
+    },
+    "blt": {
+      "name": "Tai Dam"
+    },
+    "blv": {
+      "name": "Kibala"
+    },
+    "blw": {
+      "name": "Balangao"
+    },
+    "blx": {
+      "name": "Mag-Indi Ayta"
+    },
+    "bly": {
+      "name": "Notre"
+    },
+    "blz": {
+      "name": "Balantak"
+    },
+    "bma": {
+      "name": "Lame"
+    },
+    "bmb": {
+      "name": "Bembe"
+    },
+    "bmc": {
+      "name": "Biem"
+    },
+    "bmd": {
+      "name": "Baga Manduri"
+    },
+    "bme": {
+      "name": "Limassa"
+    },
+    "bmf": {
+      "name": "Bom-Kim"
+    },
+    "bmg": {
+      "name": "Bamwe"
+    },
+    "bmh": {
+      "name": "Kein"
+    },
+    "bmi": {
+      "name": "Bagirmi"
+    },
+    "bmj": {
+      "name": "Bote-Majhi"
+    },
+    "bmk": {
+      "name": "Ghayavi"
+    },
+    "bml": {
+      "name": "Bomboli"
+    },
+    "bmm": {
+      "name": "Northern Betsimisaraka Malagasy"
+    },
+    "bmn": {
+      "name": "Bina (Papua New Guinea)"
+    },
+    "bmo": {
+      "name": "Bambalang"
+    },
+    "bmp": {
+      "name": "Bulgebi"
+    },
+    "bmq": {
+      "name": "Bomu"
+    },
+    "bmr": {
+      "name": "Muinane"
+    },
+    "bms": {
+      "name": "Bilma Kanuri"
+    },
+    "bmt": {
+      "name": "Biao Mon"
+    },
+    "bmu": {
+      "name": "Somba-Siawari"
+    },
+    "bmv": {
+      "name": "Bum"
+    },
+    "bmw": {
+      "name": "Bomwali"
+    },
+    "bmx": {
+      "name": "Baimak"
+    },
+    "bmy": {
+      "name": "Bemba (Democratic Republic of Congo)"
+    },
+    "bmz": {
+      "name": "Baramu"
+    },
+    "bna": {
+      "name": "Bonerate"
+    },
+    "bnb": {
+      "name": "Bookan"
+    },
+    "bnc": {
+      "name": "Bontok"
+    },
+    "bnd": {
+      "name": "Banda (Indonesia)"
+    },
+    "bne": {
+      "name": "Bintauna"
+    },
+    "bnf": {
+      "name": "Masiwang"
+    },
+    "bng": {
+      "name": "Benga"
+    },
+    "bni": {
+      "name": "Bangi"
+    },
+    "bnj": {
+      "name": "Eastern Tawbuid"
+    },
+    "bnk": {
+      "name": "Bierebo"
+    },
+    "bnl": {
+      "name": "Boon"
+    },
+    "bnm": {
+      "name": "Batanga"
+    },
+    "bnn": {
+      "name": "Bunun"
+    },
+    "bno": {
+      "name": "Bantoanon"
+    },
+    "bnp": {
+      "name": "Bola"
+    },
+    "bnq": {
+      "name": "Bantik"
+    },
+    "bnr": {
+      "name": "Butmas-Tur"
+    },
+    "bns": {
+      "name": "Bundeli"
+    },
+    "bnt": {
+      "name": "Bantu languages"
+    },
+    "bnu": {
+      "name": "Bentong"
+    },
+    "bnv": {
+      "name": "Bonerif"
+    },
+    "bnw": {
+      "name": "Bisis"
+    },
+    "bnx": {
+      "name": "Bangubangu"
+    },
+    "bny": {
+      "name": "Bintulu"
+    },
+    "bnz": {
+      "name": "Beezen"
+    },
+    "boa": {
+      "name": "Bora"
+    },
+    "bob": {
+      "name": "Aweer"
+    },
+    "boe": {
+      "name": "Mundabli"
+    },
+    "bof": {
+      "name": "Bolon"
+    },
+    "bog": {
+      "name": "Bamako Sign Language"
+    },
+    "boh": {
+      "name": "Boma"
+    },
+    "boi": {
+      "name": "Barbareño"
+    },
+    "boj": {
+      "name": "Anjam"
+    },
+    "bok": {
+      "name": "Bonjo"
+    },
+    "bol": {
+      "name": "Bole"
+    },
+    "bom": {
+      "name": "Berom"
+    },
+    "bon": {
+      "name": "Bine"
+    },
+    "boo": {
+      "name": "Tiemacèwè Bozo"
+    },
+    "bop": {
+      "name": "Bonkiman"
+    },
+    "boq": {
+      "name": "Bogaya"
+    },
+    "bor": {
+      "name": "Borôro"
+    },
+    "bot": {
+      "name": "Bongo"
+    },
+    "bou": {
+      "name": "Bondei"
+    },
+    "bov": {
+      "name": "Tuwuli"
+    },
+    "bow": {
+      "name": "Rema"
+    },
+    "box": {
+      "name": "Buamu"
+    },
+    "boy": {
+      "name": "Bodo (Central African Republic)"
+    },
+    "boz": {
+      "name": "Tiéyaxo Bozo"
+    },
+    "bpa": {
+      "name": "Daakaka"
+    },
+    "bpb": {
+      "name": "Barbacoas"
+    },
+    "bpd": {
+      "name": "Banda-Banda"
+    },
+    "bpg": {
+      "name": "Bonggo"
+    },
+    "bph": {
+      "name": "Botlikh"
+    },
+    "bpi": {
+      "name": "Bagupi"
+    },
+    "bpj": {
+      "name": "Binji"
+    },
+    "bpk": {
+      "name": "Orowe"
+    },
+    "bpl": {
+      "name": "Broome Pearling Lugger Pidgin"
+    },
+    "bpm": {
+      "name": "Biyom"
+    },
+    "bpn": {
+      "name": "Dzao Min"
+    },
+    "bpo": {
+      "name": "Anasi"
+    },
+    "bpp": {
+      "name": "Kaure"
+    },
+    "bpq": {
+      "name": "Banda Malay"
+    },
+    "bpr": {
+      "name": "Koronadal Blaan"
+    },
+    "bps": {
+      "name": "Sarangani Blaan"
+    },
+    "bpt": {
+      "name": "Barrow Point"
+    },
+    "bpu": {
+      "name": "Bongu"
+    },
+    "bpv": {
+      "name": "Bian Marind"
+    },
+    "bpw": {
+      "name": "Bo (Papua New Guinea)"
+    },
+    "bpx": {
+      "name": "Palya Bareli"
+    },
+    "bpy": {
+      "name": "Bishnupriya"
+    },
+    "bpz": {
+      "name": "Bilba"
+    },
+    "bqa": {
+      "name": "Tchumbuli"
+    },
+    "bqb": {
+      "name": "Bagusa"
+    },
+    "bqc": {
+      "name": "Boko (Benin)"
+    },
+    "bqd": {
+      "name": "Bung"
+    },
+    "bqf": {
+      "name": "Baga Kaloum"
+    },
+    "bqg": {
+      "name": "Bago-Kusuntu"
+    },
+    "bqh": {
+      "name": "Baima"
+    },
+    "bqi": {
+      "name": "Bakhtiari"
+    },
+    "bqj": {
+      "name": "Bandial"
+    },
+    "bqk": {
+      "name": "Banda-Mbrès"
+    },
+    "bql": {
+      "name": "Bilakura"
+    },
+    "bqm": {
+      "name": "Wumboko"
+    },
+    "bqn": {
+      "name": "Bulgarian Sign Language"
+    },
+    "bqo": {
+      "name": "Balo"
+    },
+    "bqp": {
+      "name": "Busa"
+    },
+    "bqq": {
+      "name": "Biritai"
+    },
+    "bqr": {
+      "name": "Burusu"
+    },
+    "bqs": {
+      "name": "Bosngun"
+    },
+    "bqt": {
+      "name": "Bamukumbit"
+    },
+    "bqu": {
+      "name": "Boguru"
+    },
+    "bqv": {
+      "name": "Koro Wachi"
+    },
+    "bqw": {
+      "name": "Buru (Nigeria)"
+    },
+    "bqx": {
+      "name": "Baangi"
+    },
+    "bqy": {
+      "name": "Bengkala Sign Language"
+    },
+    "bqz": {
+      "name": "Bakaka"
+    },
+    "bra": {
+      "name": "Braj"
+    },
+    "brb": {
+      "name": "Lave"
+    },
+    "brc": {
+      "name": "Berbice Creole Dutch"
+    },
+    "brd": {
+      "name": "Baraamu"
+    },
+    "brf": {
+      "name": "Bera"
+    },
+    "brg": {
+      "name": "Baure"
+    },
+    "brh": {
+      "name": "Brahui"
+    },
+    "bri": {
+      "name": "Mokpwe"
+    },
+    "brj": {
+      "name": "Bieria"
+    },
+    "brk": {
+      "name": "Birked"
+    },
+    "brl": {
+      "name": "Birwa"
+    },
+    "brm": {
+      "name": "Barambu"
+    },
+    "brn": {
+      "name": "Boruca"
+    },
+    "bro": {
+      "name": "Brokkat"
+    },
+    "brp": {
+      "name": "Barapasi"
+    },
+    "brq": {
+      "name": "Breri"
+    },
+    "brr": {
+      "name": "Birao"
+    },
+    "brs": {
+      "name": "Baras"
+    },
+    "brt": {
+      "name": "Bitare"
+    },
+    "bru": {
+      "name": "Eastern Bru"
+    },
+    "brv": {
+      "name": "Western Bru"
+    },
+    "brw": {
+      "name": "Bellari"
+    },
+    "brx": {
+      "name": "Bodo (India)"
+    },
+    "bry": {
+      "name": "Burui"
+    },
+    "brz": {
+      "name": "Bilbil"
+    },
+    "bsa": {
+      "name": "Abinomn"
+    },
+    "bsb": {
+      "name": "Brunei Bisaya"
+    },
+    "bsc": {
+      "name": "Bassari"
+    },
+    "bse": {
+      "name": "Wushi"
+    },
+    "bsf": {
+      "name": "Bauchi"
+    },
+    "bsg": {
+      "name": "Bashkardi"
+    },
+    "bsh": {
+      "name": "Kati"
+    },
+    "bsi": {
+      "name": "Bassossi"
+    },
+    "bsj": {
+      "name": "Bangwinji"
+    },
+    "bsk": {
+      "name": "Burushaski"
+    },
+    "bsl": {
+      "name": "Basa-Gumna"
+    },
+    "bsm": {
+      "name": "Busami"
+    },
+    "bsn": {
+      "name": "Barasana-Eduria"
+    },
+    "bso": {
+      "name": "Buso"
+    },
+    "bsp": {
+      "name": "Baga Sitemu"
+    },
+    "bsq": {
+      "name": "Bassa"
+    },
+    "bsr": {
+      "name": "Bassa-Kontagora"
+    },
+    "bss": {
+      "name": "Akoose"
+    },
+    "bst": {
+      "name": "Basketo"
+    },
+    "bsu": {
+      "name": "Bahonsuai"
+    },
+    "bsv": {
+      "name": "Baga Sobané"
+    },
+    "bsw": {
+      "name": "Baiso"
+    },
+    "bsx": {
+      "name": "Yangkam"
+    },
+    "bsy": {
+      "name": "Sabah Bisaya"
+    },
+    "bta": {
+      "name": "Bata"
+    },
+    "btb": {
+      "name": "Beti (Cameroon)"
+    },
+    "btc": {
+      "name": "Bati (Cameroon)"
+    },
+    "btd": {
+      "name": "Batak Dairi"
+    },
+    "bte": {
+      "name": "Gamo-Ningi"
+    },
+    "btf": {
+      "name": "Birgit"
+    },
+    "btg": {
+      "name": "Gagnoa Bété"
+    },
+    "bth": {
+      "name": "Biatah Bidayuh"
+    },
+    "bti": {
+      "name": "Burate"
+    },
+    "btj": {
+      "name": "Bacanese Malay"
+    },
+    "btk": {
+      "name": "Batak languages"
+    },
+    "btl": {
+      "name": "Bhatola"
+    },
+    "btm": {
+      "name": "Batak Mandailing"
+    },
+    "btn": {
+      "name": "Ratagnon"
+    },
+    "bto": {
+      "name": "Rinconada Bikol"
+    },
+    "btp": {
+      "name": "Budibud"
+    },
+    "btq": {
+      "name": "Batek"
+    },
+    "btr": {
+      "name": "Baetora"
+    },
+    "bts": {
+      "name": "Batak Simalungun"
+    },
+    "btt": {
+      "name": "Bete-Bendi"
+    },
+    "btu": {
+      "name": "Batu"
+    },
+    "btv": {
+      "name": "Bateri"
+    },
+    "btw": {
+      "name": "Butuanon"
+    },
+    "btx": {
+      "name": "Batak Karo"
+    },
+    "bty": {
+      "name": "Bobot"
+    },
+    "btz": {
+      "name": "Batak Alas-Kluet"
+    },
+    "bua": {
+      "name": "Buriat"
+    },
+    "bub": {
+      "name": "Bua"
+    },
+    "buc": {
+      "name": "Bushi"
+    },
+    "bud": {
+      "name": "Ntcham"
+    },
+    "bue": {
+      "name": "Beothuk"
+    },
+    "buf": {
+      "name": "Bushoong"
+    },
+    "bug": {
+      "name": "Buginese"
+    },
+    "buh": {
+      "name": "Younuo Bunu"
+    },
+    "bui": {
+      "name": "Bongili"
+    },
+    "buj": {
+      "name": "Basa-Gurmana"
+    },
+    "buk": {
+      "name": "Bugawac"
+    },
+    "bum": {
+      "name": "Bulu (Cameroon)"
+    },
+    "bun": {
+      "name": "Sherbro"
+    },
+    "buo": {
+      "name": "Terei"
+    },
+    "bup": {
+      "name": "Busoa"
+    },
+    "buq": {
+      "name": "Brem"
+    },
+    "bus": {
+      "name": "Bokobaru"
+    },
+    "but": {
+      "name": "Bungain"
+    },
+    "buu": {
+      "name": "Budu"
+    },
+    "buv": {
+      "name": "Bun"
+    },
+    "buw": {
+      "name": "Bubi"
+    },
+    "bux": {
+      "name": "Boghom"
+    },
+    "buy": {
+      "name": "Bullom So"
+    },
+    "buz": {
+      "name": "Bukwen"
+    },
+    "bva": {
+      "name": "Barein"
+    },
+    "bvb": {
+      "name": "Bube"
+    },
+    "bvc": {
+      "name": "Baelelea"
+    },
+    "bvd": {
+      "name": "Baeggu"
+    },
+    "bve": {
+      "name": "Berau Malay"
+    },
+    "bvf": {
+      "name": "Boor"
+    },
+    "bvg": {
+      "name": "Bonkeng"
+    },
+    "bvh": {
+      "name": "Bure"
+    },
+    "bvi": {
+      "name": "Belanda Viri"
+    },
+    "bvj": {
+      "name": "Baan"
+    },
+    "bvk": {
+      "name": "Bukat"
+    },
+    "bvl": {
+      "name": "Bolivian Sign Language"
+    },
+    "bvm": {
+      "name": "Bamunka"
+    },
+    "bvn": {
+      "name": "Buna"
+    },
+    "bvo": {
+      "name": "Bolgo"
+    },
+    "bvp": {
+      "name": "Bumang"
+    },
+    "bvq": {
+      "name": "Birri"
+    },
+    "bvr": {
+      "name": "Burarra"
+    },
+    "bvt": {
+      "name": "Bati (Indonesia)"
+    },
+    "bvu": {
+      "name": "Bukit Malay"
+    },
+    "bvv": {
+      "name": "Baniva"
+    },
+    "bvw": {
+      "name": "Boga"
+    },
+    "bvx": {
+      "name": "Dibole"
+    },
+    "bvy": {
+      "name": "Baybayanon"
+    },
+    "bvz": {
+      "name": "Bauzi"
+    },
+    "bwa": {
+      "name": "Bwatoo"
+    },
+    "bwb": {
+      "name": "Namosi-Naitasiri-Serua"
+    },
+    "bwc": {
+      "name": "Bwile"
+    },
+    "bwd": {
+      "name": "Bwaidoka"
+    },
+    "bwe": {
+      "name": "Bwe Karen"
+    },
+    "bwf": {
+      "name": "Boselewa"
+    },
+    "bwg": {
+      "name": "Barwe"
+    },
+    "bwh": {
+      "name": "Bishuo"
+    },
+    "bwi": {
+      "name": "Baniwa"
+    },
+    "bwj": {
+      "name": "Láá Láá Bwamu"
+    },
+    "bwk": {
+      "name": "Bauwaki"
+    },
+    "bwl": {
+      "name": "Bwela"
+    },
+    "bwm": {
+      "name": "Biwat"
+    },
+    "bwn": {
+      "name": "Wunai Bunu"
+    },
+    "bwo": {
+      "name": "Boro (Ethiopia)"
+    },
+    "bwp": {
+      "name": "Mandobo Bawah"
+    },
+    "bwq": {
+      "name": "Southern Bobo Madaré"
+    },
+    "bwr": {
+      "name": "Bura-Pabir"
+    },
+    "bws": {
+      "name": "Bomboma"
+    },
+    "bwt": {
+      "name": "Bafaw-Balong"
+    },
+    "bwu": {
+      "name": "Buli (Ghana)"
+    },
+    "bww": {
+      "name": "Bwa"
+    },
+    "bwx": {
+      "name": "Bu-Nao Bunu"
+    },
+    "bwy": {
+      "name": "Cwi Bwamu"
+    },
+    "bwz": {
+      "name": "Bwisi"
+    },
+    "bxa": {
+      "name": "Tairaha"
+    },
+    "bxb": {
+      "name": "Belanda Bor"
+    },
+    "bxc": {
+      "name": "Molengue"
+    },
+    "bxd": {
+      "name": "Pela"
+    },
+    "bxe": {
+      "name": "Birale"
+    },
+    "bxf": {
+      "name": "Bilur"
+    },
+    "bxg": {
+      "name": "Bangala"
+    },
+    "bxh": {
+      "name": "Buhutu"
+    },
+    "bxi": {
+      "name": "Pirlatapa"
+    },
+    "bxj": {
+      "name": "Bayungu"
+    },
+    "bxk": {
+      "name": "Bukusu"
+    },
+    "bxl": {
+      "name": "Jalkunan"
+    },
+    "bxm": {
+      "name": "Mongolia Buriat"
+    },
+    "bxn": {
+      "name": "Burduna"
+    },
+    "bxo": {
+      "name": "Barikanchi"
+    },
+    "bxp": {
+      "name": "Bebil"
+    },
+    "bxq": {
+      "name": "Beele"
+    },
+    "bxr": {
+      "name": "Russia Buriat"
+    },
+    "bxs": {
+      "name": "Busam"
+    },
+    "bxu": {
+      "name": "China Buriat"
+    },
+    "bxv": {
+      "name": "Berakou"
+    },
+    "bxw": {
+      "name": "Bankagooma"
+    },
+    "bxx": {
+      "name": "Borna (Democratic Republic of Congo)"
+    },
+    "bxz": {
+      "name": "Binahari"
+    },
+    "bya": {
+      "name": "Batak"
+    },
+    "byb": {
+      "name": "Bikya"
+    },
+    "byc": {
+      "name": "Ubaghara"
+    },
+    "byd": {
+      "name": "Benyadu'"
+    },
+    "bye": {
+      "name": "Pouye"
+    },
+    "byf": {
+      "name": "Bete"
+    },
+    "byg": {
+      "name": "Baygo"
+    },
+    "byh": {
+      "name": "Bhujel"
+    },
+    "byi": {
+      "name": "Buyu"
+    },
+    "byj": {
+      "name": "Bina (Nigeria)"
+    },
+    "byk": {
+      "name": "Biao"
+    },
+    "byl": {
+      "name": "Bayono"
+    },
+    "bym": {
+      "name": "Bidyara"
+    },
+    "byn": {
+      "name": "Bilin"
+    },
+    "byo": {
+      "name": "Biyo"
+    },
+    "byp": {
+      "name": "Bumaji"
+    },
+    "byq": {
+      "name": "Basay"
+    },
+    "byr": {
+      "name": "Baruya"
+    },
+    "bys": {
+      "name": "Burak"
+    },
+    "byt": {
+      "name": "Berti"
+    },
+    "byv": {
+      "name": "Medumba"
+    },
+    "byw": {
+      "name": "Belhariya"
+    },
+    "byx": {
+      "name": "Qaqet"
+    },
+    "byy": {
+      "name": "Buya"
+    },
+    "byz": {
+      "name": "Banaro"
+    },
+    "bza": {
+      "name": "Bandi"
+    },
+    "bzb": {
+      "name": "Andio"
+    },
+    "bzc": {
+      "name": "Southern Betsimisaraka Malagasy"
+    },
+    "bzd": {
+      "name": "Bribri"
+    },
+    "bze": {
+      "name": "Jenaama Bozo"
+    },
+    "bzf": {
+      "name": "Boikin"
+    },
+    "bzg": {
+      "name": "Babuza"
+    },
+    "bzh": {
+      "name": "Mapos Buang"
+    },
+    "bzi": {
+      "name": "Bisu"
+    },
+    "bzj": {
+      "name": "Belize Kriol English"
+    },
+    "bzk": {
+      "name": "Nicaragua Creole English"
+    },
+    "bzl": {
+      "name": "Boano (Sulawesi)"
+    },
+    "bzm": {
+      "name": "Bolondo"
+    },
+    "bzn": {
+      "name": "Boano (Maluku)"
+    },
+    "bzo": {
+      "name": "Bozaba"
+    },
+    "bzp": {
+      "name": "Kemberano"
+    },
+    "bzq": {
+      "name": "Buli (Indonesia)"
+    },
+    "bzr": {
+      "name": "Biri"
+    },
+    "bzs": {
+      "name": "Brazilian Sign Language"
+    },
+    "bzt": {
+      "name": "Brithenig"
+    },
+    "bzu": {
+      "name": "Burmeso"
+    },
+    "bzv": {
+      "name": "Naami"
+    },
+    "bzw": {
+      "name": "Basa (Nigeria)"
+    },
+    "bzx": {
+      "name": "Kɛlɛngaxo Bozo"
+    },
+    "bzy": {
+      "name": "Obanliku"
+    },
+    "bzz": {
+      "name": "Evant"
+    },
+    "caa": {
+      "name": "Chortí"
+    },
+    "cab": {
+      "name": "Garifuna"
+    },
+    "cac": {
+      "name": "Chuj"
+    },
+    "cad": {
+      "name": "Caddo"
+    },
+    "cae": {
+      "name": "Lehar"
+    },
+    "caf": {
+      "name": "Southern Carrier"
+    },
+    "cag": {
+      "name": "Nivaclé"
+    },
+    "cah": {
+      "name": "Cahuarano"
+    },
+    "cai": {
+      "name": "Central American Indian languages"
+    },
+    "caj": {
+      "name": "Chané"
+    },
+    "cak": {
+      "name": "Kaqchikel"
+    },
+    "cal": {
+      "name": "Carolinian"
+    },
+    "cam": {
+      "name": "Cemuhî"
+    },
+    "can": {
+      "name": "Chambri"
+    },
+    "cao": {
+      "name": "Chácobo"
+    },
+    "cap": {
+      "name": "Chipaya"
+    },
+    "caq": {
+      "name": "Car Nicobarese"
+    },
+    "car": {
+      "name": "Galibi Carib"
+    },
+    "cas": {
+      "name": "Tsimané"
+    },
+    "cau": {
+      "name": "Caucasian languages"
+    },
+    "cav": {
+      "name": "Cavineña"
+    },
+    "caw": {
+      "name": "Callawalla"
+    },
+    "cax": {
+      "name": "Chiquitano"
+    },
+    "cay": {
+      "name": "Cayuga"
+    },
+    "caz": {
+      "name": "Canichana"
+    },
+    "cba": {
+      "name": "Chibchan languages"
+    },
+    "cbb": {
+      "name": "Cabiyarí"
+    },
+    "cbc": {
+      "name": "Carapana"
+    },
+    "cbd": {
+      "name": "Carijona"
+    },
+    "cbe": {
+      "name": "Chipiajes"
+    },
+    "cbg": {
+      "name": "Chimila"
+    },
+    "cbh": {
+      "name": "Cagua"
+    },
+    "cbi": {
+      "name": "Chachi"
+    },
+    "cbj": {
+      "name": "Ede Cabe"
+    },
+    "cbk": {
+      "name": "Chavacano"
+    },
+    "cbl": {
+      "name": "Bualkhaw Chin"
+    },
+    "cbn": {
+      "name": "Nyahkur"
+    },
+    "cbo": {
+      "name": "Izora"
+    },
+    "cbq": {
+      "name": "Tsucuba"
+    },
+    "cbr": {
+      "name": "Cashibo-Cacataibo"
+    },
+    "cbs": {
+      "name": "Cashinahua"
+    },
+    "cbt": {
+      "name": "Chayahuita"
+    },
+    "cbu": {
+      "name": "Candoshi-Shapra"
+    },
+    "cbv": {
+      "name": "Cacua"
+    },
+    "cbw": {
+      "name": "Kinabalian"
+    },
+    "cby": {
+      "name": "Carabayo"
+    },
+    "cca": {
+      "name": "Cauca"
+    },
+    "ccc": {
+      "name": "Chamicuro"
+    },
+    "ccd": {
+      "name": "Cafundo Creole"
+    },
+    "cce": {
+      "name": "Chopi"
+    },
+    "ccg": {
+      "name": "Samba Daka"
+    },
+    "cch": {
+      "name": "Atsam"
+    },
+    "ccj": {
+      "name": "Kasanga"
+    },
+    "ccl": {
+      "name": "Cutchi-Swahili"
+    },
+    "ccm": {
+      "name": "Malaccan Creole Malay"
+    },
+    "ccn": {
+      "name": "North Caucasian languages"
+    },
+    "cco": {
+      "name": "Comaltepec Chinantec"
+    },
+    "ccp": {
+      "name": "Chakma"
+    },
+    "ccq": {
+      "name": "Chaungtha"
+    },
+    "ccr": {
+      "name": "Cacaopera"
+    },
+    "ccs": {
+      "name": "South Caucasian languages"
+    },
+    "cda": {
+      "name": "Choni"
+    },
+    "cdc": {
+      "name": "Chadic languages"
+    },
+    "cdd": {
+      "name": "Caddoan languages"
+    },
+    "cde": {
+      "name": "Chenchu"
+    },
+    "cdf": {
+      "name": "Chiru"
+    },
+    "cdg": {
+      "name": "Chamari"
+    },
+    "cdh": {
+      "name": "Chambeali"
+    },
+    "cdi": {
+      "name": "Chodri"
+    },
+    "cdj": {
+      "name": "Churahi"
+    },
+    "cdm": {
+      "name": "Chepang"
+    },
+    "cdn": {
+      "name": "Chaudangsi"
+    },
+    "cdo": {
+      "name": "Min Dong Chinese"
+    },
+    "cdr": {
+      "name": "Cinda-Regi-Tiyal"
+    },
+    "cds": {
+      "name": "Chadian Sign Language"
+    },
+    "cdy": {
+      "name": "Chadong"
+    },
+    "cdz": {
+      "name": "Koda"
+    },
+    "cea": {
+      "name": "Lower Chehalis"
+    },
+    "ceb": {
+      "name": "Cebuano"
+    },
+    "ceg": {
+      "name": "Chamacoco"
+    },
+    "cek": {
+      "name": "Eastern Khumi Chin"
+    },
+    "cel": {
+      "name": "Celtic languages"
+    },
+    "cen": {
+      "name": "Cen"
+    },
+    "cet": {
+      "name": "Centúúm"
+    },
+    "cfa": {
+      "name": "Dijim-Bwilim"
+    },
+    "cfd": {
+      "name": "Cara"
+    },
+    "cfg": {
+      "name": "Como Karim"
+    },
+    "cfm": {
+      "name": "Falam Chin"
+    },
+    "cga": {
+      "name": "Changriwa"
+    },
+    "cgc": {
+      "name": "Kagayanen"
+    },
+    "cgg": {
+      "name": "Chiga"
+    },
+    "cgk": {
+      "name": "Chocangacakha"
+    },
+    "chb": {
+      "name": "Chibcha"
+    },
+    "chc": {
+      "name": "Catawba"
+    },
+    "chd": {
+      "name": "Highland Oaxaca Chontal"
+    },
+    "chf": {
+      "name": "Tabasco Chontal"
+    },
+    "chg": {
+      "name": "Chagatai"
+    },
+    "chh": {
+      "name": "Chinook"
+    },
+    "chj": {
+      "name": "Ojitlán Chinantec"
+    },
+    "chk": {
+      "name": "Chuukese"
+    },
+    "chl": {
+      "name": "Cahuilla"
+    },
+    "chm": {
+      "name": "Mari (Russia)"
+    },
+    "chn": {
+      "name": "Chinook jargon"
+    },
+    "cho": {
+      "name": "Choctaw"
+    },
+    "chp": {
+      "name": "Chipewyan"
+    },
+    "chq": {
+      "name": "Quiotepec Chinantec"
+    },
+    "chr": {
+      "name": "Cherokee"
+    },
+    "cht": {
+      "name": "Cholón"
+    },
+    "chw": {
+      "name": "Chuwabu"
+    },
+    "chx": {
+      "name": "Chantyal"
+    },
+    "chy": {
+      "name": "Cheyenne"
+    },
+    "chz": {
+      "name": "Ozumacín Chinantec"
+    },
+    "cia": {
+      "name": "Cia-Cia"
+    },
+    "cib": {
+      "name": "Ci Gbe"
+    },
+    "cic": {
+      "name": "Chickasaw"
+    },
+    "cid": {
+      "name": "Chimariko"
+    },
+    "cie": {
+      "name": "Cineni"
+    },
+    "cih": {
+      "name": "Chinali"
+    },
+    "cik": {
+      "name": "Chitkuli Kinnauri"
+    },
+    "cim": {
+      "name": "Cimbrian"
+    },
+    "cin": {
+      "name": "Cinta Larga"
+    },
+    "cip": {
+      "name": "Chiapanec"
+    },
+    "cir": {
+      "name": "Tiri"
+    },
+    "ciw": {
+      "name": "Chippewa"
+    },
+    "ciy": {
+      "name": "Chaima"
+    },
+    "cja": {
+      "name": "Western Cham"
+    },
+    "cje": {
+      "name": "Chru"
+    },
+    "cjh": {
+      "name": "Upper Chehalis"
+    },
+    "cji": {
+      "name": "Chamalal"
+    },
+    "cjk": {
+      "name": "Chokwe"
+    },
+    "cjm": {
+      "name": "Eastern Cham"
+    },
+    "cjn": {
+      "name": "Chenapian"
+    },
+    "cjo": {
+      "name": "Ashéninka Pajonal"
+    },
+    "cjp": {
+      "name": "Cabécar"
+    },
+    "cjr": {
+      "name": "Chorotega"
+    },
+    "cjs": {
+      "name": "Shor"
+    },
+    "cjv": {
+      "name": "Chuave"
+    },
+    "cjy": {
+      "name": "Jinyu Chinese"
+    },
+    "cka": {
+      "name": "Khumi Awa Chin"
+    },
+    "ckb": {
+      "name": "Central Kurdish"
+    },
+    "ckh": {
+      "name": "Chak"
+    },
+    "ckl": {
+      "name": "Cibak"
+    },
+    "ckn": {
+      "name": "Kaang Chin"
+    },
+    "cko": {
+      "name": "Anufo"
+    },
+    "ckq": {
+      "name": "Kajakse"
+    },
+    "ckr": {
+      "name": "Kairak"
+    },
+    "cks": {
+      "name": "Tayo"
+    },
+    "ckt": {
+      "name": "Chukot"
+    },
+    "cku": {
+      "name": "Koasati"
+    },
+    "ckv": {
+      "name": "Kavalan"
+    },
+    "ckx": {
+      "name": "Caka"
+    },
+    "cky": {
+      "name": "Cakfem-Mushere"
+    },
+    "ckz": {
+      "name": "Cakchiquel-Quiché Mixed Language"
+    },
+    "cla": {
+      "name": "Ron"
+    },
+    "clc": {
+      "name": "Chilcotin"
+    },
+    "cld": {
+      "name": "Chaldean Neo-Aramaic"
+    },
+    "cle": {
+      "name": "Lealao Chinantec"
+    },
+    "clh": {
+      "name": "Chilisso"
+    },
+    "cli": {
+      "name": "Chakali"
+    },
+    "clj": {
+      "name": "Laitu Chin"
+    },
+    "clk": {
+      "name": "Idu-Mishmi"
+    },
+    "cll": {
+      "name": "Chala"
+    },
+    "clm": {
+      "name": "Clallam"
+    },
+    "clo": {
+      "name": "Lowland Oaxaca Chontal"
+    },
+    "clt": {
+      "name": "Lautu Chin"
+    },
+    "clu": {
+      "name": "Caluyanun"
+    },
+    "clw": {
+      "name": "Chulym"
+    },
+    "cly": {
+      "name": "Eastern Highland Chatino"
+    },
+    "cma": {
+      "name": "Maa"
+    },
+    "cmc": {
+      "name": "Chamic languages"
+    },
+    "cme": {
+      "name": "Cerma"
+    },
+    "cmg": {
+      "name": "Classical Mongolian"
+    },
+    "cmi": {
+      "name": "Emberá-Chamí"
+    },
+    "cmk": {
+      "name": "Chimakum"
+    },
+    "cml": {
+      "name": "Campalagian"
+    },
+    "cmm": {
+      "name": "Michigamea"
+    },
+    "cmn": {
+      "name": "Mandarin Chinese"
+    },
+    "cmo": {
+      "name": "Central Mnong"
+    },
+    "cmr": {
+      "name": "Mro-Khimi Chin"
+    },
+    "cms": {
+      "name": "Messapic"
+    },
+    "cmt": {
+      "name": "Camtho"
+    },
+    "cna": {
+      "name": "Changthang"
+    },
+    "cnb": {
+      "name": "Chinbon Chin"
+    },
+    "cnc": {
+      "name": "Côông"
+    },
+    "cng": {
+      "name": "Northern Qiang"
+    },
+    "cnh": {
+      "name": "Hakha Chin"
+    },
+    "cni": {
+      "name": "Asháninka"
+    },
+    "cnk": {
+      "name": "Khumi Chin"
+    },
+    "cnl": {
+      "name": "Lalana Chinantec"
+    },
+    "cno": {
+      "name": "Con"
+    },
+    "cnr": {
+      "name": "Montenegrin"
+    },
+    "cns": {
+      "name": "Central Asmat"
+    },
+    "cnt": {
+      "name": "Tepetotutla Chinantec"
+    },
+    "cnu": {
+      "name": "Chenoua"
+    },
+    "cnw": {
+      "name": "Ngawn Chin"
+    },
+    "cnx": {
+      "name": "Middle Cornish"
+    },
+    "coa": {
+      "name": "Cocos Islands Malay"
+    },
+    "cob": {
+      "name": "Chicomuceltec"
+    },
+    "coc": {
+      "name": "Cocopa"
+    },
+    "cod": {
+      "name": "Cocama-Cocamilla"
+    },
+    "coe": {
+      "name": "Koreguaje"
+    },
+    "cof": {
+      "name": "Colorado"
+    },
+    "cog": {
+      "name": "Chong"
+    },
+    "coh": {
+      "name": "Chonyi-Dzihana-Kauma"
+    },
+    "coj": {
+      "name": "Cochimi"
+    },
+    "cok": {
+      "name": "Santa Teresa Cora"
+    },
+    "col": {
+      "name": "Columbia-Wenatchi"
+    },
+    "com": {
+      "name": "Comanche"
+    },
+    "con": {
+      "name": "Cofán"
+    },
+    "coo": {
+      "name": "Comox"
+    },
+    "cop": {
+      "name": "Coptic"
+    },
+    "coq": {
+      "name": "Coquille"
+    },
+    "cot": {
+      "name": "Caquinte"
+    },
+    "cou": {
+      "name": "Wamey"
+    },
+    "cov": {
+      "name": "Cao Miao"
+    },
+    "cow": {
+      "name": "Cowlitz"
+    },
+    "cox": {
+      "name": "Nanti"
+    },
+    "coy": {
+      "name": "Coyaima"
+    },
+    "coz": {
+      "name": "Chochotec"
+    },
+    "cpa": {
+      "name": "Palantla Chinantec"
+    },
+    "cpb": {
+      "name": "Ucayali-Yurúa Ashéninka"
+    },
+    "cpc": {
+      "name": "Ajyíninka Apurucayali"
+    },
+    "cpe": {
+      "name": "English-based creoles and pidgins"
+    },
+    "cpf": {
+      "name": "French-based creoles and pidgins"
+    },
+    "cpg": {
+      "name": "Cappadocian Greek"
+    },
+    "cpi": {
+      "name": "Chinese Pidgin English"
+    },
+    "cpn": {
+      "name": "Cherepon"
+    },
+    "cpo": {
+      "name": "Kpeego"
+    },
+    "cpp": {
+      "name": "Portuguese-based creoles and pidgins"
+    },
+    "cps": {
+      "name": "Capiznon"
+    },
+    "cpu": {
+      "name": "Pichis Ashéninka"
+    },
+    "cpx": {
+      "name": "Pu-Xian Chinese"
+    },
+    "cpy": {
+      "name": "South Ucayali Ashéninka"
+    },
+    "cqd": {
+      "name": "Chuanqiandian Cluster Miao"
+    },
+    "cqu": {
+      "name": "Chilean Quechua"
+    },
+    "cra": {
+      "name": "Chara"
+    },
+    "crb": {
+      "name": "Island Carib"
+    },
+    "crc": {
+      "name": "Lonwolwol"
+    },
+    "crd": {
+      "name": "Coeur d'Alene"
+    },
+    "crf": {
+      "name": "Caramanta"
+    },
+    "crg": {
+      "name": "Michif"
+    },
+    "crh": {
+      "name": "Crimean Tatar"
+    },
+    "cri": {
+      "name": "Sãotomense"
+    },
+    "crj": {
+      "name": "Southern East Cree"
+    },
+    "crk": {
+      "name": "Plains Cree"
+    },
+    "crl": {
+      "name": "Northern East Cree"
+    },
+    "crm": {
+      "name": "Moose Cree"
+    },
+    "crn": {
+      "name": "El Nayar Cora"
+    },
+    "cro": {
+      "name": "Crow"
+    },
+    "crp": {
+      "name": "Creoles and pidgins"
+    },
+    "crq": {
+      "name": "Iyo'wujwa Chorote"
+    },
+    "crr": {
+      "name": "Carolina Algonquian"
+    },
+    "crs": {
+      "name": "Seselwa Creole French"
+    },
+    "crt": {
+      "name": "Iyojwa'ja Chorote"
+    },
+    "crv": {
+      "name": "Chaura"
+    },
+    "crw": {
+      "name": "Chrau"
+    },
+    "crx": {
+      "name": "Carrier"
+    },
+    "cry": {
+      "name": "Cori"
+    },
+    "crz": {
+      "name": "Cruzeño"
+    },
+    "csa": {
+      "name": "Chiltepec Chinantec"
+    },
+    "csb": {
+      "name": "Kashubian"
+    },
+    "csc": {
+      "name": "Catalan Sign Language"
+    },
+    "csd": {
+      "name": "Chiangmai Sign Language"
+    },
+    "cse": {
+      "name": "Czech Sign Language"
+    },
+    "csf": {
+      "name": "Cuba Sign Language"
+    },
+    "csg": {
+      "name": "Chilean Sign Language"
+    },
+    "csh": {
+      "name": "Asho Chin"
+    },
+    "csi": {
+      "name": "Coast Miwok"
+    },
+    "csj": {
+      "name": "Songlai Chin"
+    },
+    "csk": {
+      "name": "Jola-Kasa"
+    },
+    "csl": {
+      "name": "Chinese Sign Language"
+    },
+    "csm": {
+      "name": "Central Sierra Miwok"
+    },
+    "csn": {
+      "name": "Colombian Sign Language"
+    },
+    "cso": {
+      "name": "Sochiapam Chinantec"
+    },
+    "csq": {
+      "name": "Croatia Sign Language"
+    },
+    "csr": {
+      "name": "Costa Rican Sign Language"
+    },
+    "css": {
+      "name": "Southern Ohlone"
+    },
+    "cst": {
+      "name": "Northern Ohlone"
+    },
+    "csu": {
+      "name": "Central Sudanic languages"
+    },
+    "csv": {
+      "name": "Sumtu Chin"
+    },
+    "csw": {
+      "name": "Swampy Cree"
+    },
+    "csy": {
+      "name": "Siyin Chin"
+    },
+    "csz": {
+      "name": "Coos"
+    },
+    "cta": {
+      "name": "Tataltepec Chatino"
+    },
+    "ctc": {
+      "name": "Chetco"
+    },
+    "ctd": {
+      "name": "Tedim Chin"
+    },
+    "cte": {
+      "name": "Tepinapa Chinantec"
+    },
+    "ctg": {
+      "name": "Chittagonian"
+    },
+    "cth": {
+      "name": "Thaiphum Chin"
+    },
+    "ctl": {
+      "name": "Tlacoatzintepec Chinantec"
+    },
+    "ctm": {
+      "name": "Chitimacha"
+    },
+    "ctn": {
+      "name": "Chhintange"
+    },
+    "cto": {
+      "name": "Emberá-Catío"
+    },
+    "ctp": {
+      "name": "Western Highland Chatino"
+    },
+    "cts": {
+      "name": "Northern Catanduanes Bikol"
+    },
+    "ctt": {
+      "name": "Wayanad Chetti"
+    },
+    "ctu": {
+      "name": "Chol"
+    },
+    "ctz": {
+      "name": "Zacatepec Chatino"
+    },
+    "cua": {
+      "name": "Cua"
+    },
+    "cub": {
+      "name": "Cubeo"
+    },
+    "cuc": {
+      "name": "Usila Chinantec"
+    },
+    "cug": {
+      "name": "Chungmboko"
+    },
+    "cuh": {
+      "name": "Chuka"
+    },
+    "cui": {
+      "name": "Cuiba"
+    },
+    "cuj": {
+      "name": "Mashco Piro"
+    },
+    "cuk": {
+      "name": "San Blas Kuna"
+    },
+    "cul": {
+      "name": "Culina"
+    },
+    "cum": {
+      "name": "Cumeral"
+    },
+    "cuo": {
+      "name": "Cumanagoto"
+    },
+    "cup": {
+      "name": "Cupeño"
+    },
+    "cuq": {
+      "name": "Cun"
+    },
+    "cur": {
+      "name": "Chhulung"
+    },
+    "cus": {
+      "name": "Cushitic languages"
+    },
+    "cut": {
+      "name": "Teutila Cuicatec"
+    },
+    "cuu": {
+      "name": "Tai Ya"
+    },
+    "cuv": {
+      "name": "Cuvok"
+    },
+    "cuw": {
+      "name": "Chukwa"
+    },
+    "cux": {
+      "name": "Tepeuxila Cuicatec"
+    },
+    "cuy": {
+      "name": "Cuitlatec"
+    },
+    "cvg": {
+      "name": "Chug"
+    },
+    "cvn": {
+      "name": "Valle Nacional Chinantec"
+    },
+    "cwa": {
+      "name": "Kabwa"
+    },
+    "cwb": {
+      "name": "Maindo"
+    },
+    "cwd": {
+      "name": "Woods Cree"
+    },
+    "cwe": {
+      "name": "Kwere"
+    },
+    "cwg": {
+      "name": "Chewong"
+    },
+    "cwt": {
+      "name": "Kuwaataay"
+    },
+    "cya": {
+      "name": "Nopala Chatino"
+    },
+    "cyb": {
+      "name": "Cayubaba"
+    },
+    "cyo": {
+      "name": "Cuyonon"
+    },
+    "czh": {
+      "name": "Huizhou Chinese"
+    },
+    "czk": {
+      "name": "Knaanic"
+    },
+    "czn": {
+      "name": "Zenzontepec Chatino"
+    },
+    "czo": {
+      "name": "Min Zhong Chinese"
+    },
+    "czt": {
+      "name": "Zotung Chin"
+    },
+    "daa": {
+      "name": "Dangaléat"
+    },
+    "dac": {
+      "name": "Dambi"
+    },
+    "dad": {
+      "name": "Marik"
+    },
+    "dae": {
+      "name": "Duupa"
+    },
+    "daf": {
+      "name": "Dan"
+    },
+    "dag": {
+      "name": "Dagbani"
+    },
+    "dah": {
+      "name": "Gwahatike"
+    },
+    "dai": {
+      "name": "Day"
+    },
+    "daj": {
+      "name": "Dar Fur Daju"
+    },
+    "dak": {
+      "name": "Dakota"
+    },
+    "dal": {
+      "name": "Dahalo"
+    },
+    "dam": {
+      "name": "Damakawa"
+    },
+    "dao": {
+      "name": "Daai Chin"
+    },
+    "dap": {
+      "name": "Nisi (India)"
+    },
+    "daq": {
+      "name": "Dandami Maria"
+    },
+    "dar": {
+      "name": "Dargwa"
+    },
+    "das": {
+      "name": "Daho-Doo"
+    },
+    "dau": {
+      "name": "Dar Sila Daju"
+    },
+    "dav": {
+      "name": "Taita"
+    },
+    "daw": {
+      "name": "Davawenyo"
+    },
+    "dax": {
+      "name": "Dayi"
+    },
+    "day": {
+      "name": "Land Dayak languages"
+    },
+    "daz": {
+      "name": "Dao"
+    },
+    "dba": {
+      "name": "Bangime"
+    },
+    "dbb": {
+      "name": "Deno"
+    },
+    "dbd": {
+      "name": "Dadiya"
+    },
+    "dbe": {
+      "name": "Dabe"
+    },
+    "dbf": {
+      "name": "Edopi"
+    },
+    "dbg": {
+      "name": "Dogul Dom Dogon"
+    },
+    "dbi": {
+      "name": "Doka"
+    },
+    "dbj": {
+      "name": "Ida'an"
+    },
+    "dbl": {
+      "name": "Dyirbal"
+    },
+    "dbm": {
+      "name": "Duguri"
+    },
+    "dbn": {
+      "name": "Duriankere"
+    },
+    "dbo": {
+      "name": "Dulbu"
+    },
+    "dbp": {
+      "name": "Duwai"
+    },
+    "dbq": {
+      "name": "Daba"
+    },
+    "dbr": {
+      "name": "Dabarre"
+    },
+    "dbt": {
+      "name": "Ben Tey Dogon"
+    },
+    "dbu": {
+      "name": "Bondum Dom Dogon"
+    },
+    "dbv": {
+      "name": "Dungu"
+    },
+    "dbw": {
+      "name": "Bankan Tey Dogon"
+    },
+    "dby": {
+      "name": "Dibiyaso"
+    },
+    "dcc": {
+      "name": "Deccan"
+    },
+    "dcr": {
+      "name": "Negerhollands"
+    },
+    "dda": {
+      "name": "Dadi Dadi"
+    },
+    "ddd": {
+      "name": "Dongotono"
+    },
+    "dde": {
+      "name": "Doondo"
+    },
+    "ddg": {
+      "name": "Fataluku"
+    },
+    "ddi": {
+      "name": "West Goodenough"
+    },
+    "ddj": {
+      "name": "Jaru"
+    },
+    "ddn": {
+      "name": "Dendi (Benin)"
+    },
+    "ddo": {
+      "name": "Dido"
+    },
+    "ddr": {
+      "name": "Dhudhuroa"
+    },
+    "dds": {
+      "name": "Donno So Dogon"
+    },
+    "ddw": {
+      "name": "Dawera-Daweloor"
+    },
+    "dec": {
+      "name": "Dagik"
+    },
+    "ded": {
+      "name": "Dedua"
+    },
+    "dee": {
+      "name": "Dewoin"
+    },
+    "def": {
+      "name": "Dezfuli"
+    },
+    "deg": {
+      "name": "Degema"
+    },
+    "deh": {
+      "name": "Dehwari"
+    },
+    "dei": {
+      "name": "Demisa"
+    },
+    "dek": {
+      "name": "Dek"
+    },
+    "del": {
+      "name": "Delaware"
+    },
+    "dem": {
+      "name": "Dem"
+    },
+    "den": {
+      "name": "Slave (Athapascan)"
+    },
+    "dep": {
+      "name": "Pidgin Delaware"
+    },
+    "deq": {
+      "name": "Dendi (Central African Republic)"
+    },
+    "der": {
+      "name": "Deori"
+    },
+    "des": {
+      "name": "Desano"
+    },
+    "dev": {
+      "name": "Domung"
+    },
+    "dez": {
+      "name": "Dengese"
+    },
+    "dga": {
+      "name": "Southern Dagaare"
+    },
+    "dgb": {
+      "name": "Bunoge Dogon"
+    },
+    "dgc": {
+      "name": "Casiguran Dumagat Agta"
+    },
+    "dgd": {
+      "name": "Dagaari Dioula"
+    },
+    "dge": {
+      "name": "Degenan"
+    },
+    "dgg": {
+      "name": "Doga"
+    },
+    "dgh": {
+      "name": "Dghwede"
+    },
+    "dgi": {
+      "name": "Northern Dagara"
+    },
+    "dgk": {
+      "name": "Dagba"
+    },
+    "dgl": {
+      "name": "Andaandi"
+    },
+    "dgn": {
+      "name": "Dagoman"
+    },
+    "dgo": {
+      "name": "Dogri (individual language)"
+    },
+    "dgr": {
+      "name": "Dogrib"
+    },
+    "dgs": {
+      "name": "Dogoso"
+    },
+    "dgt": {
+      "name": "Ndra'ngith"
+    },
+    "dgu": {
+      "name": "Degaru"
+    },
+    "dgw": {
+      "name": "Daungwurrung"
+    },
+    "dgx": {
+      "name": "Doghoro"
+    },
+    "dgz": {
+      "name": "Daga"
+    },
+    "dha": {
+      "name": "Dhanwar (India)"
+    },
+    "dhd": {
+      "name": "Dhundari"
+    },
+    "dhg": {
+      "name": "Dhangu-Djangu"
+    },
+    "dhi": {
+      "name": "Dhimal"
+    },
+    "dhl": {
+      "name": "Dhalandji"
+    },
+    "dhm": {
+      "name": "Zemba"
+    },
+    "dhn": {
+      "name": "Dhanki"
+    },
+    "dho": {
+      "name": "Dhodia"
+    },
+    "dhr": {
+      "name": "Dhargari"
+    },
+    "dhs": {
+      "name": "Dhaiso"
+    },
+    "dhu": {
+      "name": "Dhurga"
+    },
+    "dhv": {
+      "name": "Dehu"
+    },
+    "dhw": {
+      "name": "Dhanwar (Nepal)"
+    },
+    "dhx": {
+      "name": "Dhungaloo"
+    },
+    "dia": {
+      "name": "Dia"
+    },
+    "dib": {
+      "name": "South Central Dinka"
+    },
+    "dic": {
+      "name": "Lakota Dida"
+    },
+    "did": {
+      "name": "Didinga"
+    },
+    "dif": {
+      "name": "Dieri"
+    },
+    "dig": {
+      "name": "Digo"
+    },
+    "dih": {
+      "name": "Kumiai"
+    },
+    "dii": {
+      "name": "Dimbong"
+    },
+    "dij": {
+      "name": "Dai"
+    },
+    "dik": {
+      "name": "Southwestern Dinka"
+    },
+    "dil": {
+      "name": "Dilling"
+    },
+    "dim": {
+      "name": "Dime"
+    },
+    "din": {
+      "name": "Dinka"
+    },
+    "dio": {
+      "name": "Dibo"
+    },
+    "dip": {
+      "name": "Northeastern Dinka"
+    },
+    "diq": {
+      "name": "Dimli (individual language)"
+    },
+    "dir": {
+      "name": "Dirim"
+    },
+    "dis": {
+      "name": "Dimasa"
+    },
+    "dit": {
+      "name": "Dirari"
+    },
+    "diu": {
+      "name": "Diriku"
+    },
+    "diw": {
+      "name": "Northwestern Dinka"
+    },
+    "dix": {
+      "name": "Dixon Reef"
+    },
+    "diy": {
+      "name": "Diuwe"
+    },
+    "diz": {
+      "name": "Ding"
+    },
+    "dja": {
+      "name": "Djadjawurrung"
+    },
+    "djb": {
+      "name": "Djinba"
+    },
+    "djc": {
+      "name": "Dar Daju Daju"
+    },
+    "djd": {
+      "name": "Djamindjung"
+    },
+    "dje": {
+      "name": "Zarma"
+    },
+    "djf": {
+      "name": "Djangun"
+    },
+    "dji": {
+      "name": "Djinang"
+    },
+    "djj": {
+      "name": "Djeebbana"
+    },
+    "djk": {
+      "name": "Eastern Maroon Creole"
+    },
+    "djl": {
+      "name": "Djiwarli"
+    },
+    "djm": {
+      "name": "Jamsay Dogon"
+    },
+    "djn": {
+      "name": "Djauan"
+    },
+    "djo": {
+      "name": "Jangkang"
+    },
+    "djr": {
+      "name": "Djambarrpuyngu"
+    },
+    "dju": {
+      "name": "Kapriman"
+    },
+    "djw": {
+      "name": "Djawi"
+    },
+    "dka": {
+      "name": "Dakpakha"
+    },
+    "dkk": {
+      "name": "Dakka"
+    },
+    "dkl": {
+      "name": "Kolum So Dogon"
+    },
+    "dkr": {
+      "name": "Kuijau"
+    },
+    "dks": {
+      "name": "Southeastern Dinka"
+    },
+    "dkx": {
+      "name": "Mazagway"
+    },
+    "dlg": {
+      "name": "Dolgan"
+    },
+    "dlk": {
+      "name": "Dahalik"
+    },
+    "dlm": {
+      "name": "Dalmatian"
+    },
+    "dln": {
+      "name": "Darlong"
+    },
+    "dma": {
+      "name": "Duma"
+    },
+    "dmb": {
+      "name": "Mombo Dogon"
+    },
+    "dmc": {
+      "name": "Gavak"
+    },
+    "dmd": {
+      "name": "Madhi Madhi"
+    },
+    "dme": {
+      "name": "Dugwor"
+    },
+    "dmg": {
+      "name": "Upper Kinabatangan"
+    },
+    "dmk": {
+      "name": "Domaaki"
+    },
+    "dml": {
+      "name": "Dameli"
+    },
+    "dmm": {
+      "name": "Dama"
+    },
+    "dmn": {
+      "name": "Mande languages"
+    },
+    "dmo": {
+      "name": "Kemedzung"
+    },
+    "dmr": {
+      "name": "East Damar"
+    },
+    "dms": {
+      "name": "Dampelas"
+    },
+    "dmu": {
+      "name": "Dubu"
+    },
+    "dmv": {
+      "name": "Dumpas"
+    },
+    "dmw": {
+      "name": "Mudburra"
+    },
+    "dmx": {
+      "name": "Dema"
+    },
+    "dmy": {
+      "name": "Demta"
+    },
+    "dna": {
+      "name": "Upper Grand Valley Dani"
+    },
+    "dnd": {
+      "name": "Daonda"
+    },
+    "dne": {
+      "name": "Ndendeule"
+    },
+    "dng": {
+      "name": "Dungan"
+    },
+    "dni": {
+      "name": "Lower Grand Valley Dani"
+    },
+    "dnj": {
+      "name": "Dan"
+    },
+    "dnk": {
+      "name": "Dengka"
+    },
+    "dnn": {
+      "name": "Dzùùngoo"
+    },
+    "dnr": {
+      "name": "Danaru"
+    },
+    "dnt": {
+      "name": "Mid Grand Valley Dani"
+    },
+    "dnu": {
+      "name": "Danau"
+    },
+    "dnv": {
+      "name": "Danu"
+    },
+    "dnw": {
+      "name": "Western Dani"
+    },
+    "dny": {
+      "name": "Dení"
+    },
+    "doa": {
+      "name": "Dom"
+    },
+    "dob": {
+      "name": "Dobu"
+    },
+    "doc": {
+      "name": "Northern Dong"
+    },
+    "doe": {
+      "name": "Doe"
+    },
+    "dof": {
+      "name": "Domu"
+    },
+    "doh": {
+      "name": "Dong"
+    },
+    "doi": {
+      "name": "Dogri (macrolanguage)"
+    },
+    "dok": {
+      "name": "Dondo"
+    },
+    "dol": {
+      "name": "Doso"
+    },
+    "don": {
+      "name": "Toura (Papua New Guinea)"
+    },
+    "doo": {
+      "name": "Dongo"
+    },
+    "dop": {
+      "name": "Lukpa"
+    },
+    "doq": {
+      "name": "Dominican Sign Language"
+    },
+    "dor": {
+      "name": "Dori'o"
+    },
+    "dos": {
+      "name": "Dogosé"
+    },
+    "dot": {
+      "name": "Dass"
+    },
+    "dov": {
+      "name": "Dombe"
+    },
+    "dow": {
+      "name": "Doyayo"
+    },
+    "dox": {
+      "name": "Bussa"
+    },
+    "doy": {
+      "name": "Dompo"
+    },
+    "doz": {
+      "name": "Dorze"
+    },
+    "dpp": {
+      "name": "Papar"
+    },
+    "dra": {
+      "name": "Dravidian languages"
+    },
+    "drb": {
+      "name": "Dair"
+    },
+    "drc": {
+      "name": "Minderico"
+    },
+    "drd": {
+      "name": "Darmiya"
+    },
+    "dre": {
+      "name": "Dolpo"
+    },
+    "drg": {
+      "name": "Rungus"
+    },
+    "drh": {
+      "name": "Darkhat"
+    },
+    "dri": {
+      "name": "C'Lela"
+    },
+    "drl": {
+      "name": "Paakantyi"
+    },
+    "drn": {
+      "name": "West Damar"
+    },
+    "dro": {
+      "name": "Daro-Matu Melanau"
+    },
+    "drq": {
+      "name": "Dura"
+    },
+    "drr": {
+      "name": "Dororo"
+    },
+    "drs": {
+      "name": "Gedeo"
+    },
+    "drt": {
+      "name": "Drents"
+    },
+    "dru": {
+      "name": "Rukai"
+    },
+    "drw": {
+      "name": "Darwazi"
+    },
+    "dry": {
+      "name": "Darai"
+    },
+    "dsb": {
+      "name": "Lower Sorbian"
+    },
+    "dse": {
+      "name": "Dutch Sign Language"
+    },
+    "dsh": {
+      "name": "Daasanach"
+    },
+    "dsi": {
+      "name": "Disa"
+    },
+    "dsl": {
+      "name": "Danish Sign Language"
+    },
+    "dsn": {
+      "name": "Dusner"
+    },
+    "dso": {
+      "name": "Desiya"
+    },
+    "dsq": {
+      "name": "Tadaksahak"
+    },
+    "dta": {
+      "name": "Daur"
+    },
+    "dtb": {
+      "name": "Labuk-Kinabatangan Kadazan"
+    },
+    "dtd": {
+      "name": "Ditidaht"
+    },
+    "dth": {
+      "name": "Adithinngithigh"
+    },
+    "dti": {
+      "name": "Ana Tinga Dogon"
+    },
+    "dtk": {
+      "name": "Tene Kan Dogon"
+    },
+    "dtm": {
+      "name": "Tomo Kan Dogon"
+    },
+    "dtn": {
+      "name": "Daatsʼíin"
+    },
+    "dto": {
+      "name": "Tommo So Dogon"
+    },
+    "dtp": {
+      "name": "Kadazan Dusun"
+    },
+    "dtr": {
+      "name": "Lotud"
+    },
+    "dts": {
+      "name": "Toro So Dogon"
+    },
+    "dtt": {
+      "name": "Toro Tegu Dogon"
+    },
+    "dtu": {
+      "name": "Tebul Ure Dogon"
+    },
+    "dty": {
+      "name": "Dotyali"
+    },
+    "dua": {
+      "name": "Duala"
+    },
+    "dub": {
+      "name": "Dubli"
+    },
+    "duc": {
+      "name": "Duna"
+    },
+    "dud": {
+      "name": "Hun-Saare"
+    },
+    "due": {
+      "name": "Umiray Dumaget Agta"
+    },
+    "duf": {
+      "name": "Dumbea"
+    },
+    "dug": {
+      "name": "Duruma"
+    },
+    "duh": {
+      "name": "Dungra Bhil"
+    },
+    "dui": {
+      "name": "Dumun"
+    },
+    "duj": {
+      "name": "Dhuwal"
+    },
+    "duk": {
+      "name": "Uyajitaya"
+    },
+    "dul": {
+      "name": "Alabat Island Agta"
+    },
+    "dum": {
+      "name": "Middle Dutch (ca. 1050-1350)"
+    },
+    "dun": {
+      "name": "Dusun Deyah"
+    },
+    "duo": {
+      "name": "Dupaninan Agta"
+    },
+    "dup": {
+      "name": "Duano"
+    },
+    "duq": {
+      "name": "Dusun Malang"
+    },
+    "dur": {
+      "name": "Dii"
+    },
+    "dus": {
+      "name": "Dumi"
+    },
+    "duu": {
+      "name": "Drung"
+    },
+    "duv": {
+      "name": "Duvle"
+    },
+    "duw": {
+      "name": "Dusun Witu"
+    },
+    "dux": {
+      "name": "Duungooma"
+    },
+    "duy": {
+      "name": "Dicamay Agta"
+    },
+    "duz": {
+      "name": "Duli-Gey"
+    },
+    "dva": {
+      "name": "Duau"
+    },
+    "dwa": {
+      "name": "Diri"
+    },
+    "dwl": {
+      "name": "Walo Kumbe Dogon"
+    },
+    "dwr": {
+      "name": "Dawro"
+    },
+    "dws": {
+      "name": "Dutton World Speedwords"
+    },
+    "dwu": {
+      "name": "Dhuwal"
+    },
+    "dww": {
+      "name": "Dawawa"
+    },
+    "dwy": {
+      "name": "Dhuwaya"
+    },
+    "dya": {
+      "name": "Dyan"
+    },
+    "dyb": {
+      "name": "Dyaberdyaber"
+    },
+    "dyd": {
+      "name": "Dyugun"
+    },
+    "dyg": {
+      "name": "Villa Viciosa Agta"
+    },
+    "dyi": {
+      "name": "Djimini Senoufo"
+    },
+    "dym": {
+      "name": "Yanda Dom Dogon"
+    },
+    "dyn": {
+      "name": "Dyangadi"
+    },
+    "dyo": {
+      "name": "Jola-Fonyi"
+    },
+    "dyu": {
+      "name": "Dyula"
+    },
+    "dyy": {
+      "name": "Dyaabugay"
+    },
+    "dza": {
+      "name": "Tunzu"
+    },
+    "dzd": {
+      "name": "Daza"
+    },
+    "dze": {
+      "name": "Djiwarli"
+    },
+    "dzg": {
+      "name": "Dazaga"
+    },
+    "dzl": {
+      "name": "Dzalakha"
+    },
+    "dzn": {
+      "name": "Dzando"
+    },
+    "eaa": {
+      "name": "Karenggapa"
+    },
+    "ebg": {
+      "name": "Ebughu"
+    },
+    "ebk": {
+      "name": "Eastern Bontok"
+    },
+    "ebo": {
+      "name": "Teke-Ebo"
+    },
+    "ebr": {
+      "name": "Ebrié"
+    },
+    "ebu": {
+      "name": "Embu"
+    },
+    "ecr": {
+      "name": "Eteocretan"
+    },
+    "ecs": {
+      "name": "Ecuadorian Sign Language"
+    },
+    "ecy": {
+      "name": "Eteocypriot"
+    },
+    "eee": {
+      "name": "E"
+    },
+    "efa": {
+      "name": "Efai"
+    },
+    "efe": {
+      "name": "Efe"
+    },
+    "efi": {
+      "name": "Efik"
+    },
+    "ega": {
+      "name": "Ega"
+    },
+    "egl": {
+      "name": "Emilian"
+    },
+    "ego": {
+      "name": "Eggon"
+    },
+    "egx": {
+      "name": "Egyptian languages"
+    },
+    "egy": {
+      "name": "Egyptian (Ancient)"
+    },
+    "ehu": {
+      "name": "Ehueun"
+    },
+    "eip": {
+      "name": "Eipomek"
+    },
+    "eit": {
+      "name": "Eitiep"
+    },
+    "eiv": {
+      "name": "Askopan"
+    },
+    "eja": {
+      "name": "Ejamat"
+    },
+    "eka": {
+      "name": "Ekajuk"
+    },
+    "ekc": {
+      "name": "Eastern Karnic"
+    },
+    "eke": {
+      "name": "Ekit"
+    },
+    "ekg": {
+      "name": "Ekari"
+    },
+    "eki": {
+      "name": "Eki"
+    },
+    "ekk": {
+      "name": "Standard Estonian"
+    },
+    "ekl": {
+      "name": "Kol (Bangladesh)"
+    },
+    "ekm": {
+      "name": "Elip"
+    },
+    "eko": {
+      "name": "Koti"
+    },
+    "ekp": {
+      "name": "Ekpeye"
+    },
+    "ekr": {
+      "name": "Yace"
+    },
+    "eky": {
+      "name": "Eastern Kayah"
+    },
+    "ele": {
+      "name": "Elepi"
+    },
+    "elh": {
+      "name": "El Hugeirat"
+    },
+    "eli": {
+      "name": "Nding"
+    },
+    "elk": {
+      "name": "Elkei"
+    },
+    "elm": {
+      "name": "Eleme"
+    },
+    "elo": {
+      "name": "El Molo"
+    },
+    "elp": {
+      "name": "Elpaputih"
+    },
+    "elu": {
+      "name": "Elu"
+    },
+    "elx": {
+      "name": "Elamite"
+    },
+    "ema": {
+      "name": "Emai-Iuleha-Ora"
+    },
+    "emb": {
+      "name": "Embaloh"
+    },
+    "eme": {
+      "name": "Emerillon"
+    },
+    "emg": {
+      "name": "Eastern Meohang"
+    },
+    "emi": {
+      "name": "Mussau-Emira"
+    },
+    "emk": {
+      "name": "Eastern Maninkakan"
+    },
+    "emm": {
+      "name": "Mamulique"
+    },
+    "emn": {
+      "name": "Eman"
+    },
+    "emo": {
+      "name": "Emok"
+    },
+    "emp": {
+      "name": "Northern Emberá"
+    },
+    "ems": {
+      "name": "Pacific Gulf Yupik"
+    },
+    "emu": {
+      "name": "Eastern Muria"
+    },
+    "emw": {
+      "name": "Emplawas"
+    },
+    "emx": {
+      "name": "Erromintxela"
+    },
+    "emy": {
+      "name": "Epigraphic Mayan"
+    },
+    "ena": {
+      "name": "Apali"
+    },
+    "enb": {
+      "name": "Markweeta"
+    },
+    "enc": {
+      "name": "En"
+    },
+    "end": {
+      "name": "Ende"
+    },
+    "enf": {
+      "name": "Forest Enets"
+    },
+    "enh": {
+      "name": "Tundra Enets"
+    },
+    "enl": {
+      "name": "Enlhet"
+    },
+    "enm": {
+      "name": "Middle English (1100-1500)"
+    },
+    "enn": {
+      "name": "Engenni"
+    },
+    "eno": {
+      "name": "Enggano"
+    },
+    "enq": {
+      "name": "Enga"
+    },
+    "enr": {
+      "name": "Emumu"
+    },
+    "enu": {
+      "name": "Enu"
+    },
+    "env": {
+      "name": "Enwan (Edu State)"
+    },
+    "enw": {
+      "name": "Enwan (Akwa Ibom State)"
+    },
+    "enx": {
+      "name": "Enxet"
+    },
+    "eot": {
+      "name": "Beti (Côte d'Ivoire)"
+    },
+    "epi": {
+      "name": "Epie"
+    },
+    "era": {
+      "name": "Eravallan"
+    },
+    "erg": {
+      "name": "Sie"
+    },
+    "erh": {
+      "name": "Eruwa"
+    },
+    "eri": {
+      "name": "Ogea"
+    },
+    "erk": {
+      "name": "South Efate"
+    },
+    "ero": {
+      "name": "Horpa"
+    },
+    "err": {
+      "name": "Erre"
+    },
+    "ers": {
+      "name": "Ersu"
+    },
+    "ert": {
+      "name": "Eritai"
+    },
+    "erw": {
+      "name": "Erokwanas"
+    },
+    "ese": {
+      "name": "Ese Ejja"
+    },
+    "esg": {
+      "name": "Aheri Gondi"
+    },
+    "esh": {
+      "name": "Eshtehardi"
+    },
+    "esi": {
+      "name": "North Alaskan Inupiatun"
+    },
+    "esk": {
+      "name": "Northwest Alaska Inupiatun"
+    },
+    "esl": {
+      "name": "Egypt Sign Language"
+    },
+    "esm": {
+      "name": "Esuma"
+    },
+    "esn": {
+      "name": "Salvadoran Sign Language"
+    },
+    "eso": {
+      "name": "Estonian Sign Language"
+    },
+    "esq": {
+      "name": "Esselen"
+    },
+    "ess": {
+      "name": "Central Siberian Yupik"
+    },
+    "esu": {
+      "name": "Central Yupik"
+    },
+    "esx": {
+      "name": "Eskimo-Aleut languages"
+    },
+    "esy": {
+      "name": "Eskayan"
+    },
+    "etb": {
+      "name": "Etebi"
+    },
+    "etc": {
+      "name": "Etchemin"
+    },
+    "eth": {
+      "name": "Ethiopian Sign Language"
+    },
+    "etn": {
+      "name": "Eton (Vanuatu)"
+    },
+    "eto": {
+      "name": "Eton (Cameroon)"
+    },
+    "etr": {
+      "name": "Edolo"
+    },
+    "ets": {
+      "name": "Yekhee"
+    },
+    "ett": {
+      "name": "Etruscan"
+    },
+    "etu": {
+      "name": "Ejagham"
+    },
+    "etx": {
+      "name": "Eten"
+    },
+    "etz": {
+      "name": "Semimi"
+    },
+    "euq": {
+      "name": "Basque (family)"
+    },
+    "eve": {
+      "name": "Even"
+    },
+    "evh": {
+      "name": "Uvbie"
+    },
+    "evn": {
+      "name": "Evenki"
+    },
+    "ewo": {
+      "name": "Ewondo"
+    },
+    "ext": {
+      "name": "Extremaduran"
+    },
+    "eya": {
+      "name": "Eyak"
+    },
+    "eyo": {
+      "name": "Keiyo"
+    },
+    "eza": {
+      "name": "Ezaa"
+    },
+    "eze": {
+      "name": "Uzekwe"
+    },
+    "faa": {
+      "name": "Fasu"
+    },
+    "fab": {
+      "name": "Fa d'Ambu"
+    },
+    "fad": {
+      "name": "Wagi"
+    },
+    "faf": {
+      "name": "Fagani"
+    },
+    "fag": {
+      "name": "Finongan"
+    },
+    "fah": {
+      "name": "Baissa Fali"
+    },
+    "fai": {
+      "name": "Faiwol"
+    },
+    "faj": {
+      "name": "Faita"
+    },
+    "fak": {
+      "name": "Fang (Cameroon)"
+    },
+    "fal": {
+      "name": "South Fali"
+    },
+    "fam": {
+      "name": "Fam"
+    },
+    "fan": {
+      "name": "Fang (Equatorial Guinea)"
+    },
+    "fap": {
+      "name": "Paloor"
+    },
+    "far": {
+      "name": "Fataleka"
+    },
+    "fat": {
+      "name": "Fanti"
+    },
+    "fau": {
+      "name": "Fayu"
+    },
+    "fax": {
+      "name": "Fala"
+    },
+    "fay": {
+      "name": "Southwestern Fars"
+    },
+    "faz": {
+      "name": "Northwestern Fars"
+    },
+    "fbl": {
+      "name": "West Albay Bikol"
+    },
+    "fcs": {
+      "name": "Quebec Sign Language"
+    },
+    "fer": {
+      "name": "Feroge"
+    },
+    "ffi": {
+      "name": "Foia Foia"
+    },
+    "ffm": {
+      "name": "Maasina Fulfulde"
+    },
+    "fgr": {
+      "name": "Fongoro"
+    },
+    "fia": {
+      "name": "Nobiin"
+    },
+    "fie": {
+      "name": "Fyer"
+    },
+    "fil": {
+      "name": "Filipino"
+    },
+    "fip": {
+      "name": "Fipa"
+    },
+    "fir": {
+      "name": "Firan"
+    },
+    "fit": {
+      "name": "Tornedalen Finnish"
+    },
+    "fiu": {
+      "name": "Finno-Ugrian languages"
+    },
+    "fiw": {
+      "name": "Fiwaga"
+    },
+    "fkk": {
+      "name": "Kirya-Konzəl"
+    },
+    "fkv": {
+      "name": "Kven Finnish"
+    },
+    "fla": {
+      "name": "Kalispel-Pend d'Oreille"
+    },
+    "flh": {
+      "name": "Foau"
+    },
+    "fli": {
+      "name": "Fali"
+    },
+    "fll": {
+      "name": "North Fali"
+    },
+    "fln": {
+      "name": "Flinders Island"
+    },
+    "flr": {
+      "name": "Fuliiru"
+    },
+    "fly": {
+      "name": "Flaaitaal"
+    },
+    "fmp": {
+      "name": "Fe'fe'"
+    },
+    "fmu": {
+      "name": "Far Western Muria"
+    },
+    "fnb": {
+      "name": "Fanbak"
+    },
+    "fng": {
+      "name": "Fanagalo"
+    },
+    "fni": {
+      "name": "Fania"
+    },
+    "fod": {
+      "name": "Foodo"
+    },
+    "foi": {
+      "name": "Foi"
+    },
+    "fom": {
+      "name": "Foma"
+    },
+    "fon": {
+      "name": "Fon"
+    },
+    "for": {
+      "name": "Fore"
+    },
+    "fos": {
+      "name": "Siraya"
+    },
+    "fox": {
+      "name": "Formosan languages"
+    },
+    "fpe": {
+      "name": "Fernando Po Creole English"
+    },
+    "fqs": {
+      "name": "Fas"
+    },
+    "frc": {
+      "name": "Cajun French"
+    },
+    "frd": {
+      "name": "Fordata"
+    },
+    "frk": {
+      "name": "Frankish"
+    },
+    "frm": {
+      "name": "Middle French (ca. 1400-1600)"
+    },
+    "fro": {
+      "name": "Old French (842-ca. 1400)"
+    },
+    "frp": {
+      "name": "Arpitan"
+    },
+    "frq": {
+      "name": "Forak"
+    },
+    "frr": {
+      "name": "Northern Frisian"
+    },
+    "frs": {
+      "name": "Eastern Frisian"
+    },
+    "frt": {
+      "name": "Fortsenal"
+    },
+    "fse": {
+      "name": "Finnish Sign Language"
+    },
+    "fsl": {
+      "name": "French Sign Language"
+    },
+    "fss": {
+      "name": "Finland-Swedish Sign Language"
+    },
+    "fub": {
+      "name": "Adamawa Fulfulde"
+    },
+    "fuc": {
+      "name": "Pulaar"
+    },
+    "fud": {
+      "name": "East Futuna"
+    },
+    "fue": {
+      "name": "Borgu Fulfulde"
+    },
+    "fuf": {
+      "name": "Pular"
+    },
+    "fuh": {
+      "name": "Western Niger Fulfulde"
+    },
+    "fui": {
+      "name": "Bagirmi Fulfulde"
+    },
+    "fuj": {
+      "name": "Ko"
+    },
+    "fum": {
+      "name": "Fum"
+    },
+    "fun": {
+      "name": "Fulniô"
+    },
+    "fuq": {
+      "name": "Central-Eastern Niger Fulfulde"
+    },
+    "fur": {
+      "name": "Friulian"
+    },
+    "fut": {
+      "name": "Futuna-Aniwa"
+    },
+    "fuu": {
+      "name": "Furu"
+    },
+    "fuv": {
+      "name": "Nigerian Fulfulde"
+    },
+    "fuy": {
+      "name": "Fuyug"
+    },
+    "fvr": {
+      "name": "Fur"
+    },
+    "fwa": {
+      "name": "Fwâi"
+    },
+    "fwe": {
+      "name": "Fwe"
+    },
+    "gaa": {
+      "name": "Ga"
+    },
+    "gab": {
+      "name": "Gabri"
+    },
+    "gac": {
+      "name": "Mixed Great Andamanese"
+    },
+    "gad": {
+      "name": "Gaddang"
+    },
+    "gae": {
+      "name": "Guarequena"
+    },
+    "gaf": {
+      "name": "Gende"
+    },
+    "gag": {
+      "name": "Gagauz"
+    },
+    "gah": {
+      "name": "Alekano"
+    },
+    "gai": {
+      "name": "Borei"
+    },
+    "gaj": {
+      "name": "Gadsup"
+    },
+    "gak": {
+      "name": "Gamkonora"
+    },
+    "gal": {
+      "name": "Galolen"
+    },
+    "gam": {
+      "name": "Kandawo"
+    },
+    "gan": {
+      "name": "Gan Chinese"
+    },
+    "gao": {
+      "name": "Gants"
+    },
+    "gap": {
+      "name": "Gal"
+    },
+    "gaq": {
+      "name": "Gata'"
+    },
+    "gar": {
+      "name": "Galeya"
+    },
+    "gas": {
+      "name": "Adiwasi Garasia"
+    },
+    "gat": {
+      "name": "Kenati"
+    },
+    "gau": {
+      "name": "Mudhili Gadaba"
+    },
+    "gav": {
+      "name": "Gabutamon"
+    },
+    "gaw": {
+      "name": "Nobonob"
+    },
+    "gax": {
+      "name": "Borana-Arsi-Guji Oromo"
+    },
+    "gay": {
+      "name": "Gayo"
+    },
+    "gaz": {
+      "name": "West Central Oromo"
+    },
+    "gba": {
+      "name": "Gbaya (Central African Republic)"
+    },
+    "gbb": {
+      "name": "Kaytetye"
+    },
+    "gbc": {
+      "name": "Garawa"
+    },
+    "gbd": {
+      "name": "Karadjeri"
+    },
+    "gbe": {
+      "name": "Niksek"
+    },
+    "gbf": {
+      "name": "Gaikundi"
+    },
+    "gbg": {
+      "name": "Gbanziri"
+    },
+    "gbh": {
+      "name": "Defi Gbe"
+    },
+    "gbi": {
+      "name": "Galela"
+    },
+    "gbj": {
+      "name": "Bodo Gadaba"
+    },
+    "gbk": {
+      "name": "Gaddi"
+    },
+    "gbl": {
+      "name": "Gamit"
+    },
+    "gbm": {
+      "name": "Garhwali"
+    },
+    "gbn": {
+      "name": "Mo'da"
+    },
+    "gbo": {
+      "name": "Northern Grebo"
+    },
+    "gbp": {
+      "name": "Gbaya-Bossangoa"
+    },
+    "gbq": {
+      "name": "Gbaya-Bozoum"
+    },
+    "gbr": {
+      "name": "Gbagyi"
+    },
+    "gbs": {
+      "name": "Gbesi Gbe"
+    },
+    "gbu": {
+      "name": "Gagadu"
+    },
+    "gbv": {
+      "name": "Gbanu"
+    },
+    "gbw": {
+      "name": "Gabi-Gabi"
+    },
+    "gbx": {
+      "name": "Eastern Xwla Gbe"
+    },
+    "gby": {
+      "name": "Gbari"
+    },
+    "gbz": {
+      "name": "Zoroastrian Dari"
+    },
+    "gcc": {
+      "name": "Mali"
+    },
+    "gcd": {
+      "name": "Ganggalida"
+    },
+    "gce": {
+      "name": "Galice"
+    },
+    "gcf": {
+      "name": "Guadeloupean Creole French"
+    },
+    "gcl": {
+      "name": "Grenadian Creole English"
+    },
+    "gcn": {
+      "name": "Gaina"
+    },
+    "gcr": {
+      "name": "Guianese Creole French"
+    },
+    "gct": {
+      "name": "Colonia Tovar German"
+    },
+    "gda": {
+      "name": "Gade Lohar"
+    },
+    "gdb": {
+      "name": "Pottangi Ollar Gadaba"
+    },
+    "gdc": {
+      "name": "Gugu Badhun"
+    },
+    "gdd": {
+      "name": "Gedaged"
+    },
+    "gde": {
+      "name": "Gude"
+    },
+    "gdf": {
+      "name": "Guduf-Gava"
+    },
+    "gdg": {
+      "name": "Ga'dang"
+    },
+    "gdh": {
+      "name": "Gadjerawang"
+    },
+    "gdi": {
+      "name": "Gundi"
+    },
+    "gdj": {
+      "name": "Gurdjar"
+    },
+    "gdk": {
+      "name": "Gadang"
+    },
+    "gdl": {
+      "name": "Dirasha"
+    },
+    "gdm": {
+      "name": "Laal"
+    },
+    "gdn": {
+      "name": "Umanakaina"
+    },
+    "gdo": {
+      "name": "Ghodoberi"
+    },
+    "gdq": {
+      "name": "Mehri"
+    },
+    "gdr": {
+      "name": "Wipi"
+    },
+    "gds": {
+      "name": "Ghandruk Sign Language"
+    },
+    "gdt": {
+      "name": "Kungardutyi"
+    },
+    "gdu": {
+      "name": "Gudu"
+    },
+    "gdx": {
+      "name": "Godwari"
+    },
+    "gea": {
+      "name": "Geruma"
+    },
+    "geb": {
+      "name": "Kire"
+    },
+    "gec": {
+      "name": "Gboloo Grebo"
+    },
+    "ged": {
+      "name": "Gade"
+    },
+    "geg": {
+      "name": "Gengle"
+    },
+    "geh": {
+      "name": "Hutterite German"
+    },
+    "gei": {
+      "name": "Gebe"
+    },
+    "gej": {
+      "name": "Gen"
+    },
+    "gek": {
+      "name": "Ywom"
+    },
+    "gel": {
+      "name": "ut-Ma'in"
+    },
+    "gem": {
+      "name": "Germanic languages"
+    },
+    "geq": {
+      "name": "Geme"
+    },
+    "ges": {
+      "name": "Geser-Gorom"
+    },
+    "gev": {
+      "name": "Eviya"
+    },
+    "gew": {
+      "name": "Gera"
+    },
+    "gex": {
+      "name": "Garre"
+    },
+    "gey": {
+      "name": "Enya"
+    },
+    "gez": {
+      "name": "Geez"
+    },
+    "gfk": {
+      "name": "Patpatar"
+    },
+    "gft": {
+      "name": "Gafat"
+    },
+    "gfx": {
+      "name": "Mangetti Dune !Xung"
+    },
+    "gga": {
+      "name": "Gao"
+    },
+    "ggb": {
+      "name": "Gbii"
+    },
+    "ggd": {
+      "name": "Gugadj"
+    },
+    "gge": {
+      "name": "Guragone"
+    },
+    "ggg": {
+      "name": "Gurgula"
+    },
+    "ggk": {
+      "name": "Kungarakany"
+    },
+    "ggl": {
+      "name": "Ganglau"
+    },
+    "ggn": {
+      "name": "Eastern Gurung"
+    },
+    "ggo": {
+      "name": "Southern Gondi"
+    },
+    "ggr": {
+      "name": "Aghu Tharnggalu"
+    },
+    "ggt": {
+      "name": "Gitua"
+    },
+    "ggu": {
+      "name": "Gagu"
+    },
+    "ggw": {
+      "name": "Gogodala"
+    },
+    "gha": {
+      "name": "Ghadamès"
+    },
+    "ghc": {
+      "name": "Hiberno-Scottish Gaelic"
+    },
+    "ghe": {
+      "name": "Southern Ghale"
+    },
+    "ghh": {
+      "name": "Northern Ghale"
+    },
+    "ghk": {
+      "name": "Geko Karen"
+    },
+    "ghl": {
+      "name": "Ghulfan"
+    },
+    "ghn": {
+      "name": "Ghanongga"
+    },
+    "gho": {
+      "name": "Ghomara"
+    },
+    "ghr": {
+      "name": "Ghera"
+    },
+    "ghs": {
+      "name": "Guhu-Samane"
+    },
+    "ght": {
+      "name": "Kuke"
+    },
+    "gia": {
+      "name": "Kitja"
+    },
+    "gib": {
+      "name": "Gibanawa"
+    },
+    "gic": {
+      "name": "Gail"
+    },
+    "gid": {
+      "name": "Gidar"
+    },
+    "gie": {
+      "name": "Gaɓogbo"
+    },
+    "gig": {
+      "name": "Goaria"
+    },
+    "gih": {
+      "name": "Githabul"
+    },
+    "gil": {
+      "name": "Gilbertese"
+    },
+    "gim": {
+      "name": "Gimi (Eastern Highlands)"
+    },
+    "gin": {
+      "name": "Hinukh"
+    },
+    "gio": {
+      "name": "Gelao"
+    },
+    "gip": {
+      "name": "Gimi (West New Britain)"
+    },
+    "giq": {
+      "name": "Green Gelao"
+    },
+    "gir": {
+      "name": "Red Gelao"
+    },
+    "gis": {
+      "name": "North Giziga"
+    },
+    "git": {
+      "name": "Gitxsan"
+    },
+    "giu": {
+      "name": "Mulao"
+    },
+    "giw": {
+      "name": "White Gelao"
+    },
+    "gix": {
+      "name": "Gilima"
+    },
+    "giy": {
+      "name": "Giyug"
+    },
+    "giz": {
+      "name": "South Giziga"
+    },
+    "gji": {
+      "name": "Geji"
+    },
+    "gjk": {
+      "name": "Kachi Koli"
+    },
+    "gjm": {
+      "name": "Gunditjmara"
+    },
+    "gjn": {
+      "name": "Gonja"
+    },
+    "gjr": {
+      "name": "Gurindji Kriol"
+    },
+    "gju": {
+      "name": "Gujari"
+    },
+    "gka": {
+      "name": "Guya"
+    },
+    "gkd": {
+      "name": "Magɨ (Madang Province)"
+    },
+    "gke": {
+      "name": "Ndai"
+    },
+    "gkn": {
+      "name": "Gokana"
+    },
+    "gko": {
+      "name": "Kok-Nar"
+    },
+    "gkp": {
+      "name": "Guinea Kpelle"
+    },
+    "gku": {
+      "name": "ǂUngkue"
+    },
+    "glc": {
+      "name": "Bon Gula"
+    },
+    "gld": {
+      "name": "Nanai"
+    },
+    "glh": {
+      "name": "Northwest Pashai"
+    },
+    "gli": {
+      "name": "Guliguli"
+    },
+    "glj": {
+      "name": "Gula Iro"
+    },
+    "glk": {
+      "name": "Gilaki"
+    },
+    "gll": {
+      "name": "Garlali"
+    },
+    "glo": {
+      "name": "Galambu"
+    },
+    "glr": {
+      "name": "Glaro-Twabo"
+    },
+    "glu": {
+      "name": "Gula (Chad)"
+    },
+    "glw": {
+      "name": "Glavda"
+    },
+    "gly": {
+      "name": "Gule"
+    },
+    "gma": {
+      "name": "Gambera"
+    },
+    "gmb": {
+      "name": "Gula'alaa"
+    },
+    "gmd": {
+      "name": "Mághdì"
+    },
+    "gme": {
+      "name": "East Germanic languages"
+    },
+    "gmg": {
+      "name": "Magɨyi"
+    },
+    "gmh": {
+      "name": "Middle High German (ca. 1050-1500)"
+    },
+    "gml": {
+      "name": "Middle Low German"
+    },
+    "gmm": {
+      "name": "Gbaya-Mbodomo"
+    },
+    "gmn": {
+      "name": "Gimnime"
+    },
+    "gmq": {
+      "name": "North Germanic languages"
+    },
+    "gmu": {
+      "name": "Gumalu"
+    },
+    "gmv": {
+      "name": "Gamo"
+    },
+    "gmw": {
+      "name": "West Germanic languages"
+    },
+    "gmx": {
+      "name": "Magoma"
+    },
+    "gmy": {
+      "name": "Mycenaean Greek"
+    },
+    "gmz": {
+      "name": "Mgbolizhia"
+    },
+    "gna": {
+      "name": "Kaansa"
+    },
+    "gnb": {
+      "name": "Gangte"
+    },
+    "gnc": {
+      "name": "Guanche"
+    },
+    "gnd": {
+      "name": "Zulgo-Gemzek"
+    },
+    "gne": {
+      "name": "Ganang"
+    },
+    "gng": {
+      "name": "Ngangam"
+    },
+    "gnh": {
+      "name": "Lere"
+    },
+    "gni": {
+      "name": "Gooniyandi"
+    },
+    "gnj": {
+      "name": "Ngen"
+    },
+    "gnk": {
+      "name": "//Gana"
+    },
+    "gnl": {
+      "name": "Gangulu"
+    },
+    "gnm": {
+      "name": "Ginuman"
+    },
+    "gnn": {
+      "name": "Gumatj"
+    },
+    "gno": {
+      "name": "Northern Gondi"
+    },
+    "gnq": {
+      "name": "Gana"
+    },
+    "gnr": {
+      "name": "Gureng Gureng"
+    },
+    "gnt": {
+      "name": "Guntai"
+    },
+    "gnu": {
+      "name": "Gnau"
+    },
+    "gnw": {
+      "name": "Western Bolivian Guaraní"
+    },
+    "gnz": {
+      "name": "Ganzi"
+    },
+    "goa": {
+      "name": "Guro"
+    },
+    "gob": {
+      "name": "Playero"
+    },
+    "goc": {
+      "name": "Gorakor"
+    },
+    "god": {
+      "name": "Godié"
+    },
+    "goe": {
+      "name": "Gongduk"
+    },
+    "gof": {
+      "name": "Gofa"
+    },
+    "gog": {
+      "name": "Gogo"
+    },
+    "goh": {
+      "name": "Old High German (ca. 750-1050)"
+    },
+    "goi": {
+      "name": "Gobasi"
+    },
+    "goj": {
+      "name": "Gowlan"
+    },
+    "gok": {
+      "name": "Gowli"
+    },
+    "gol": {
+      "name": "Gola"
+    },
+    "gom": {
+      "name": "Goan Konkani"
+    },
+    "gon": {
+      "name": "Gondi"
+    },
+    "goo": {
+      "name": "Gone Dau"
+    },
+    "gop": {
+      "name": "Yeretuar"
+    },
+    "goq": {
+      "name": "Gorap"
+    },
+    "gor": {
+      "name": "Gorontalo"
+    },
+    "gos": {
+      "name": "Gronings"
+    },
+    "got": {
+      "name": "Gothic"
+    },
+    "gou": {
+      "name": "Gavar"
+    },
+    "gow": {
+      "name": "Gorowa"
+    },
+    "gox": {
+      "name": "Gobu"
+    },
+    "goy": {
+      "name": "Goundo"
+    },
+    "goz": {
+      "name": "Gozarkhani"
+    },
+    "gpa": {
+      "name": "Gupa-Abawa"
+    },
+    "gpe": {
+      "name": "Ghanaian Pidgin English"
+    },
+    "gpn": {
+      "name": "Taiap"
+    },
+    "gqa": {
+      "name": "Ga'anda"
+    },
+    "gqi": {
+      "name": "Guiqiong"
+    },
+    "gqn": {
+      "name": "Guana (Brazil)"
+    },
+    "gqr": {
+      "name": "Gor"
+    },
+    "gqu": {
+      "name": "Qau"
+    },
+    "gra": {
+      "name": "Rajput Garasia"
+    },
+    "grb": {
+      "name": "Grebo"
+    },
+    "grc": {
+      "name": "Ancient Greek (to 1453)"
+    },
+    "grd": {
+      "name": "Guruntum-Mbaaru"
+    },
+    "grg": {
+      "name": "Madi"
+    },
+    "grh": {
+      "name": "Gbiri-Niragu"
+    },
+    "gri": {
+      "name": "Ghari"
+    },
+    "grj": {
+      "name": "Southern Grebo"
+    },
+    "grk": {
+      "name": "Greek languages"
+    },
+    "grm": {
+      "name": "Kota Marudu Talantang"
+    },
+    "gro": {
+      "name": "Groma"
+    },
+    "grq": {
+      "name": "Gorovu"
+    },
+    "grr": {
+      "name": "Taznatit"
+    },
+    "grs": {
+      "name": "Gresi"
+    },
+    "grt": {
+      "name": "Garo"
+    },
+    "gru": {
+      "name": "Kistane"
+    },
+    "grv": {
+      "name": "Central Grebo"
+    },
+    "grw": {
+      "name": "Gweda"
+    },
+    "grx": {
+      "name": "Guriaso"
+    },
+    "gry": {
+      "name": "Barclayville Grebo"
+    },
+    "grz": {
+      "name": "Guramalum"
+    },
+    "gse": {
+      "name": "Ghanaian Sign Language"
+    },
+    "gsg": {
+      "name": "German Sign Language"
+    },
+    "gsl": {
+      "name": "Gusilay"
+    },
+    "gsm": {
+      "name": "Guatemalan Sign Language"
+    },
+    "gsn": {
+      "name": "Nema"
+    },
+    "gso": {
+      "name": "Southwest Gbaya"
+    },
+    "gsp": {
+      "name": "Wasembo"
+    },
+    "gss": {
+      "name": "Greek Sign Language"
+    },
+    "gsw": {
+      "name": "Swiss German"
+    },
+    "gta": {
+      "name": "Guató"
+    },
+    "gti": {
+      "name": "Gbati-ri"
+    },
+    "gtu": {
+      "name": "Aghu-Tharnggala"
+    },
+    "gua": {
+      "name": "Shiki"
+    },
+    "gub": {
+      "name": "Guajajára"
+    },
+    "guc": {
+      "name": "Wayuu"
+    },
+    "gud": {
+      "name": "Yocoboué Dida"
+    },
+    "gue": {
+      "name": "Gurinji"
+    },
+    "guf": {
+      "name": "Gupapuyngu"
+    },
+    "gug": {
+      "name": "Paraguayan Guaraní"
+    },
+    "guh": {
+      "name": "Guahibo"
+    },
+    "gui": {
+      "name": "Eastern Bolivian Guaraní"
+    },
+    "guk": {
+      "name": "Gumuz"
+    },
+    "gul": {
+      "name": "Sea Island Creole English"
+    },
+    "gum": {
+      "name": "Guambiano"
+    },
+    "gun": {
+      "name": "Mbyá Guaraní"
+    },
+    "guo": {
+      "name": "Guayabero"
+    },
+    "gup": {
+      "name": "Gunwinggu"
+    },
+    "guq": {
+      "name": "Aché"
+    },
+    "gur": {
+      "name": "Farefare"
+    },
+    "gus": {
+      "name": "Guinean Sign Language"
+    },
+    "gut": {
+      "name": "Maléku Jaíka"
+    },
+    "guu": {
+      "name": "Yanomamö"
+    },
+    "guv": {
+      "name": "Gey"
+    },
+    "guw": {
+      "name": "Gun"
+    },
+    "gux": {
+      "name": "Gourmanchéma"
+    },
+    "guz": {
+      "name": "Gusii"
+    },
+    "gva": {
+      "name": "Guana (Paraguay)"
+    },
+    "gvc": {
+      "name": "Guanano"
+    },
+    "gve": {
+      "name": "Duwet"
+    },
+    "gvf": {
+      "name": "Golin"
+    },
+    "gvj": {
+      "name": "Guajá"
+    },
+    "gvl": {
+      "name": "Gulay"
+    },
+    "gvm": {
+      "name": "Gurmana"
+    },
+    "gvn": {
+      "name": "Kuku-Yalanji"
+    },
+    "gvo": {
+      "name": "Gavião Do Jiparaná"
+    },
+    "gvp": {
+      "name": "Pará Gavião"
+    },
+    "gvr": {
+      "name": "Gurung"
+    },
+    "gvs": {
+      "name": "Gumawana"
+    },
+    "gvy": {
+      "name": "Guyani"
+    },
+    "gwa": {
+      "name": "Mbato"
+    },
+    "gwb": {
+      "name": "Gwa"
+    },
+    "gwc": {
+      "name": "Kalami"
+    },
+    "gwd": {
+      "name": "Gawwada"
+    },
+    "gwe": {
+      "name": "Gweno"
+    },
+    "gwf": {
+      "name": "Gowro"
+    },
+    "gwg": {
+      "name": "Moo"
+    },
+    "gwi": {
+      "name": "Gwichʼin"
+    },
+    "gwj": {
+      "name": "/Gwi"
+    },
+    "gwm": {
+      "name": "Awngthim"
+    },
+    "gwn": {
+      "name": "Gwandara"
+    },
+    "gwr": {
+      "name": "Gwere"
+    },
+    "gwt": {
+      "name": "Gawar-Bati"
+    },
+    "gwu": {
+      "name": "Guwamu"
+    },
+    "gww": {
+      "name": "Kwini"
+    },
+    "gwx": {
+      "name": "Gua"
+    },
+    "gxx": {
+      "name": "Wè Southern"
+    },
+    "gya": {
+      "name": "Northwest Gbaya"
+    },
+    "gyb": {
+      "name": "Garus"
+    },
+    "gyd": {
+      "name": "Kayardild"
+    },
+    "gye": {
+      "name": "Gyem"
+    },
+    "gyf": {
+      "name": "Gungabula"
+    },
+    "gyg": {
+      "name": "Gbayi"
+    },
+    "gyi": {
+      "name": "Gyele"
+    },
+    "gyl": {
+      "name": "Gayil"
+    },
+    "gym": {
+      "name": "Ngäbere"
+    },
+    "gyn": {
+      "name": "Guyanese Creole English"
+    },
+    "gyo": {
+      "name": "Gyalsumdo"
+    },
+    "gyr": {
+      "name": "Guarayu"
+    },
+    "gyy": {
+      "name": "Gunya"
+    },
+    "gza": {
+      "name": "Ganza"
+    },
+    "gzi": {
+      "name": "Gazi"
+    },
+    "gzn": {
+      "name": "Gane"
+    },
+    "haa": {
+      "name": "Han"
+    },
+    "hab": {
+      "name": "Hanoi Sign Language"
+    },
+    "hac": {
+      "name": "Gurani"
+    },
+    "had": {
+      "name": "Hatam"
+    },
+    "hae": {
+      "name": "Eastern Oromo"
+    },
+    "haf": {
+      "name": "Haiphong Sign Language"
+    },
+    "hag": {
+      "name": "Hanga"
+    },
+    "hah": {
+      "name": "Hahon"
+    },
+    "hai": {
+      "name": "Haida"
+    },
+    "haj": {
+      "name": "Hajong"
+    },
+    "hak": {
+      "name": "Hakka Chinese"
+    },
+    "hal": {
+      "name": "Halang"
+    },
+    "ham": {
+      "name": "Hewa"
+    },
+    "han": {
+      "name": "Hangaza"
+    },
+    "hao": {
+      "name": "Hakö"
+    },
+    "hap": {
+      "name": "Hupla"
+    },
+    "haq": {
+      "name": "Ha"
+    },
+    "har": {
+      "name": "Harari"
+    },
+    "has": {
+      "name": "Haisla"
+    },
+    "hav": {
+      "name": "Havu"
+    },
+    "haw": {
+      "name": "Hawaiian"
+    },
+    "hax": {
+      "name": "Southern Haida"
+    },
+    "hay": {
+      "name": "Haya"
+    },
+    "haz": {
+      "name": "Hazaragi"
+    },
+    "hba": {
+      "name": "Hamba"
+    },
+    "hbb": {
+      "name": "Huba"
+    },
+    "hbn": {
+      "name": "Heiban"
+    },
+    "hbo": {
+      "name": "Ancient Hebrew"
+    },
+    "hbu": {
+      "name": "Habu"
+    },
+    "hca": {
+      "name": "Andaman Creole Hindi"
+    },
+    "hch": {
+      "name": "Huichol"
+    },
+    "hdn": {
+      "name": "Northern Haida"
+    },
+    "hds": {
+      "name": "Honduras Sign Language"
+    },
+    "hdy": {
+      "name": "Hadiyya"
+    },
+    "hea": {
+      "name": "Northern Qiandong Miao"
+    },
+    "hed": {
+      "name": "Herdé"
+    },
+    "heg": {
+      "name": "Helong"
+    },
+    "heh": {
+      "name": "Hehe"
+    },
+    "hei": {
+      "name": "Heiltsuk"
+    },
+    "hem": {
+      "name": "Hemba"
+    },
+    "hgm": {
+      "name": "Hai//om"
+    },
+    "hgw": {
+      "name": "Haigwai"
+    },
+    "hhi": {
+      "name": "Hoia Hoia"
+    },
+    "hhr": {
+      "name": "Kerak"
+    },
+    "hhy": {
+      "name": "Hoyahoya"
+    },
+    "hia": {
+      "name": "Lamang"
+    },
+    "hib": {
+      "name": "Hibito"
+    },
+    "hid": {
+      "name": "Hidatsa"
+    },
+    "hif": {
+      "name": "Fiji Hindi"
+    },
+    "hig": {
+      "name": "Kamwe"
+    },
+    "hih": {
+      "name": "Pamosu"
+    },
+    "hii": {
+      "name": "Hinduri"
+    },
+    "hij": {
+      "name": "Hijuk"
+    },
+    "hik": {
+      "name": "Seit-Kaitetu"
+    },
+    "hil": {
+      "name": "Hiligaynon"
+    },
+    "him": {
+      "name": "Himachali languages"
+    },
+    "hio": {
+      "name": "Tsoa"
+    },
+    "hir": {
+      "name": "Himarimã"
+    },
+    "hit": {
+      "name": "Hittite"
+    },
+    "hiw": {
+      "name": "Hiw"
+    },
+    "hix": {
+      "name": "Hixkaryána"
+    },
+    "hji": {
+      "name": "Haji"
+    },
+    "hka": {
+      "name": "Kahe"
+    },
+    "hke": {
+      "name": "Hunde"
+    },
+    "hkk": {
+      "name": "Hunjara-Kaina Ke"
+    },
+    "hkn": {
+      "name": "Mel-Khaonh"
+    },
+    "hks": {
+      "name": "Hong Kong Sign Language"
+    },
+    "hla": {
+      "name": "Halia"
+    },
+    "hlb": {
+      "name": "Halbi"
+    },
+    "hld": {
+      "name": "Halang Doan"
+    },
+    "hle": {
+      "name": "Hlersu"
+    },
+    "hlt": {
+      "name": "Matu Chin"
+    },
+    "hlu": {
+      "name": "Hieroglyphic Luwian"
+    },
+    "hma": {
+      "name": "Southern Mashan Hmong"
+    },
+    "hmb": {
+      "name": "Humburi Senni Songhay"
+    },
+    "hmc": {
+      "name": "Central Huishui Hmong"
+    },
+    "hmd": {
+      "name": "Large Flowery Miao"
+    },
+    "hme": {
+      "name": "Eastern Huishui Hmong"
+    },
+    "hmf": {
+      "name": "Hmong Don"
+    },
+    "hmg": {
+      "name": "Southwestern Guiyang Hmong"
+    },
+    "hmh": {
+      "name": "Southwestern Huishui Hmong"
+    },
+    "hmi": {
+      "name": "Northern Huishui Hmong"
+    },
+    "hmj": {
+      "name": "Ge"
+    },
+    "hmk": {
+      "name": "Maek"
+    },
+    "hml": {
+      "name": "Luopohe Hmong"
+    },
+    "hmm": {
+      "name": "Central Mashan Hmong"
+    },
+    "hmn": {
+      "name": "Hmong"
+    },
+    "hmp": {
+      "name": "Northern Mashan Hmong"
+    },
+    "hmq": {
+      "name": "Eastern Qiandong Miao"
+    },
+    "hmr": {
+      "name": "Hmar"
+    },
+    "hms": {
+      "name": "Southern Qiandong Miao"
+    },
+    "hmt": {
+      "name": "Hamtai"
+    },
+    "hmu": {
+      "name": "Hamap"
+    },
+    "hmv": {
+      "name": "Hmong Dô"
+    },
+    "hmw": {
+      "name": "Western Mashan Hmong"
+    },
+    "hmx": {
+      "name": "Hmong-Mien languages"
+    },
+    "hmy": {
+      "name": "Southern Guiyang Hmong"
+    },
+    "hmz": {
+      "name": "Hmong Shua"
+    },
+    "hna": {
+      "name": "Mina (Cameroon)"
+    },
+    "hnd": {
+      "name": "Southern Hindko"
+    },
+    "hne": {
+      "name": "Chhattisgarhi"
+    },
+    "hnh": {
+      "name": "//Ani"
+    },
+    "hni": {
+      "name": "Hani"
+    },
+    "hnj": {
+      "name": "Hmong Njua"
+    },
+    "hnn": {
+      "name": "Hanunoo"
+    },
+    "hno": {
+      "name": "Northern Hindko"
+    },
+    "hns": {
+      "name": "Caribbean Hindustani"
+    },
+    "hnu": {
+      "name": "Hung"
+    },
+    "hoa": {
+      "name": "Hoava"
+    },
+    "hob": {
+      "name": "Mari (Madang Province)"
+    },
+    "hoc": {
+      "name": "Ho"
+    },
+    "hod": {
+      "name": "Holma"
+    },
+    "hoe": {
+      "name": "Horom"
+    },
+    "hoh": {
+      "name": "Hobyót"
+    },
+    "hoi": {
+      "name": "Holikachuk"
+    },
+    "hoj": {
+      "name": "Hadothi"
+    },
+    "hok": {
+      "name": "Hokan languages"
+    },
+    "hol": {
+      "name": "Holu"
+    },
+    "hom": {
+      "name": "Homa"
+    },
+    "hoo": {
+      "name": "Holoholo"
+    },
+    "hop": {
+      "name": "Hopi"
+    },
+    "hor": {
+      "name": "Horo"
+    },
+    "hos": {
+      "name": "Ho Chi Minh City Sign Language"
+    },
+    "hot": {
+      "name": "Hote"
+    },
+    "hov": {
+      "name": "Hovongan"
+    },
+    "how": {
+      "name": "Honi"
+    },
+    "hoy": {
+      "name": "Holiya"
+    },
+    "hoz": {
+      "name": "Hozo"
+    },
+    "hpo": {
+      "name": "Hpon"
+    },
+    "hps": {
+      "name": "Hawai'i Sign Language (HSL)"
+    },
+    "hra": {
+      "name": "Hrangkhol"
+    },
+    "hrc": {
+      "name": "Niwer Mil"
+    },
+    "hre": {
+      "name": "Hre"
+    },
+    "hrk": {
+      "name": "Haruku"
+    },
+    "hrm": {
+      "name": "Horned Miao"
+    },
+    "hro": {
+      "name": "Haroi"
+    },
+    "hrp": {
+      "name": "Nhirrpi"
+    },
+    "hrr": {
+      "name": "Horuru"
+    },
+    "hrt": {
+      "name": "Hértevin"
+    },
+    "hru": {
+      "name": "Hruso"
+    },
+    "hrw": {
+      "name": "Warwar Feni"
+    },
+    "hrx": {
+      "name": "Hunsrik"
+    },
+    "hrz": {
+      "name": "Harzani"
+    },
+    "hsb": {
+      "name": "Upper Sorbian"
+    },
+    "hsh": {
+      "name": "Hungarian Sign Language"
+    },
+    "hsl": {
+      "name": "Hausa Sign Language"
+    },
+    "hsn": {
+      "name": "Xiang Chinese"
+    },
+    "hss": {
+      "name": "Harsusi"
+    },
+    "hti": {
+      "name": "Hoti"
+    },
+    "hto": {
+      "name": "Minica Huitoto"
+    },
+    "hts": {
+      "name": "Hadza"
+    },
+    "htu": {
+      "name": "Hitu"
+    },
+    "htx": {
+      "name": "Middle Hittite"
+    },
+    "hub": {
+      "name": "Huambisa"
+    },
+    "huc": {
+      "name": "=/Hua"
+    },
+    "hud": {
+      "name": "Huaulu"
+    },
+    "hue": {
+      "name": "San Francisco Del Mar Huave"
+    },
+    "huf": {
+      "name": "Humene"
+    },
+    "hug": {
+      "name": "Huachipaeri"
+    },
+    "huh": {
+      "name": "Huilliche"
+    },
+    "hui": {
+      "name": "Huli"
+    },
+    "huj": {
+      "name": "Northern Guiyang Hmong"
+    },
+    "huk": {
+      "name": "Hulung"
+    },
+    "hul": {
+      "name": "Hula"
+    },
+    "hum": {
+      "name": "Hungana"
+    },
+    "huo": {
+      "name": "Hu"
+    },
+    "hup": {
+      "name": "Hupa"
+    },
+    "huq": {
+      "name": "Tsat"
+    },
+    "hur": {
+      "name": "Halkomelem"
+    },
+    "hus": {
+      "name": "Huastec"
+    },
+    "hut": {
+      "name": "Humla"
+    },
+    "huu": {
+      "name": "Murui Huitoto"
+    },
+    "huv": {
+      "name": "San Mateo Del Mar Huave"
+    },
+    "huw": {
+      "name": "Hukumina"
+    },
+    "hux": {
+      "name": "Nüpode Huitoto"
+    },
+    "huy": {
+      "name": "Hulaulá"
+    },
+    "huz": {
+      "name": "Hunzib"
+    },
+    "hvc": {
+      "name": "Haitian Vodoun Culture Language"
+    },
+    "hve": {
+      "name": "San Dionisio Del Mar Huave"
+    },
+    "hvk": {
+      "name": "Haveke"
+    },
+    "hvn": {
+      "name": "Sabu"
+    },
+    "hvv": {
+      "name": "Santa María Del Mar Huave"
+    },
+    "hwa": {
+      "name": "Wané"
+    },
+    "hwc": {
+      "name": "Hawai'i Creole English"
+    },
+    "hwo": {
+      "name": "Hwana"
+    },
+    "hya": {
+      "name": "Hya"
+    },
+    "hyw": {
+      "name": "Western Armenian"
+    },
+    "hyx": {
+      "name": "Armenian (family)"
+    },
+    "iai": {
+      "name": "Iaai"
+    },
+    "ian": {
+      "name": "Iatmul"
+    },
+    "iap": {
+      "name": "Iapama"
+    },
+    "iar": {
+      "name": "Purari"
+    },
+    "iba": {
+      "name": "Iban"
+    },
+    "ibb": {
+      "name": "Ibibio"
+    },
+    "ibd": {
+      "name": "Iwaidja"
+    },
+    "ibe": {
+      "name": "Akpes"
+    },
+    "ibg": {
+      "name": "Ibanag"
+    },
+    "ibh": {
+      "name": "Bih"
+    },
+    "ibi": {
+      "name": "Ibilo"
+    },
+    "ibl": {
+      "name": "Ibaloi"
+    },
+    "ibm": {
+      "name": "Agoi"
+    },
+    "ibn": {
+      "name": "Ibino"
+    },
+    "ibr": {
+      "name": "Ibuoro"
+    },
+    "ibu": {
+      "name": "Ibu"
+    },
+    "iby": {
+      "name": "Ibani"
+    },
+    "ica": {
+      "name": "Ede Ica"
+    },
+    "ich": {
+      "name": "Etkywan"
+    },
+    "icl": {
+      "name": "Icelandic Sign Language"
+    },
+    "icr": {
+      "name": "Islander Creole English"
+    },
+    "ida": {
+      "name": "Idakho-Isukha-Tiriki"
+    },
+    "idb": {
+      "name": "Indo-Portuguese"
+    },
+    "idc": {
+      "name": "Idon"
+    },
+    "idd": {
+      "name": "Ede Idaca"
+    },
+    "ide": {
+      "name": "Idere"
+    },
+    "idi": {
+      "name": "Idi"
+    },
+    "idr": {
+      "name": "Indri"
+    },
+    "ids": {
+      "name": "Idesa"
+    },
+    "idt": {
+      "name": "Idaté"
+    },
+    "idu": {
+      "name": "Idoma"
+    },
+    "ifa": {
+      "name": "Amganad Ifugao"
+    },
+    "ifb": {
+      "name": "Batad Ifugao"
+    },
+    "ife": {
+      "name": "Ifè"
+    },
+    "iff": {
+      "name": "Ifo"
+    },
+    "ifk": {
+      "name": "Tuwali Ifugao"
+    },
+    "ifm": {
+      "name": "Teke-Fuumu"
+    },
+    "ifu": {
+      "name": "Mayoyao Ifugao"
+    },
+    "ify": {
+      "name": "Keley-I Kallahan"
+    },
+    "igb": {
+      "name": "Ebira"
+    },
+    "ige": {
+      "name": "Igede"
+    },
+    "igg": {
+      "name": "Igana"
+    },
+    "igl": {
+      "name": "Igala"
+    },
+    "igm": {
+      "name": "Kanggape"
+    },
+    "ign": {
+      "name": "Ignaciano"
+    },
+    "igo": {
+      "name": "Isebe"
+    },
+    "igs": {
+      "name": "Interglossa"
+    },
+    "igw": {
+      "name": "Igwe"
+    },
+    "ihb": {
+      "name": "Iha Based Pidgin"
+    },
+    "ihi": {
+      "name": "Ihievbe"
+    },
+    "ihp": {
+      "name": "Iha"
+    },
+    "ihw": {
+      "name": "Bidhawal"
+    },
+    "iin": {
+      "name": "Thiin"
+    },
+    "iir": {
+      "name": "Indo-Iranian languages"
+    },
+    "ijc": {
+      "name": "Izon"
+    },
+    "ije": {
+      "name": "Biseni"
+    },
+    "ijj": {
+      "name": "Ede Ije"
+    },
+    "ijn": {
+      "name": "Kalabari"
+    },
+    "ijo": {
+      "name": "Ijo languages"
+    },
+    "ijs": {
+      "name": "Southeast Ijo"
+    },
+    "ike": {
+      "name": "Eastern Canadian Inuktitut"
+    },
+    "iki": {
+      "name": "Iko"
+    },
+    "ikk": {
+      "name": "Ika"
+    },
+    "ikl": {
+      "name": "Ikulu"
+    },
+    "iko": {
+      "name": "Olulumo-Ikom"
+    },
+    "ikp": {
+      "name": "Ikpeshi"
+    },
+    "ikr": {
+      "name": "Ikaranggal"
+    },
+    "iks": {
+      "name": "Inuit Sign Language"
+    },
+    "ikt": {
+      "name": "Inuinnaqtun"
+    },
+    "ikv": {
+      "name": "Iku-Gora-Ankwa"
+    },
+    "ikw": {
+      "name": "Ikwere"
+    },
+    "ikx": {
+      "name": "Ik"
+    },
+    "ikz": {
+      "name": "Ikizu"
+    },
+    "ila": {
+      "name": "Ile Ape"
+    },
+    "ilb": {
+      "name": "Ila"
+    },
+    "ilg": {
+      "name": "Garig-Ilgar"
+    },
+    "ili": {
+      "name": "Ili Turki"
+    },
+    "ilk": {
+      "name": "Ilongot"
+    },
+    "ill": {
+      "name": "Iranun"
+    },
+    "ilm": {
+      "name": "Iranun (Malaysia)"
+    },
+    "ilo": {
+      "name": "Iloko"
+    },
+    "ilp": {
+      "name": "Iranun (Philippines)"
+    },
+    "ils": {
+      "name": "International Sign"
+    },
+    "ilu": {
+      "name": "Ili'uun"
+    },
+    "ilv": {
+      "name": "Ilue"
+    },
+    "ilw": {
+      "name": "Talur"
+    },
+    "ima": {
+      "name": "Mala Malasar"
+    },
+    "ime": {
+      "name": "Imeraguen"
+    },
+    "imi": {
+      "name": "Anamgura"
+    },
+    "iml": {
+      "name": "Miluk"
+    },
+    "imn": {
+      "name": "Imonda"
+    },
+    "imo": {
+      "name": "Imbongu"
+    },
+    "imr": {
+      "name": "Imroing"
+    },
+    "ims": {
+      "name": "Marsian"
+    },
+    "imy": {
+      "name": "Milyan"
+    },
+    "inb": {
+      "name": "Inga"
+    },
+    "inc": {
+      "name": "Indic languages"
+    },
+    "ine": {
+      "name": "Indo-European languages"
+    },
+    "ing": {
+      "name": "Degexit'an"
+    },
+    "inh": {
+      "name": "Ingush"
+    },
+    "inj": {
+      "name": "Jungle Inga"
+    },
+    "inl": {
+      "name": "Indonesian Sign Language"
+    },
+    "inm": {
+      "name": "Minaean"
+    },
+    "inn": {
+      "name": "Isinai"
+    },
+    "ino": {
+      "name": "Inoke-Yate"
+    },
+    "inp": {
+      "name": "Iñapari"
+    },
+    "ins": {
+      "name": "Indian Sign Language"
+    },
+    "int": {
+      "name": "Intha"
+    },
+    "inz": {
+      "name": "Ineseño"
+    },
+    "ior": {
+      "name": "Inor"
+    },
+    "iou": {
+      "name": "Tuma-Irumu"
+    },
+    "iow": {
+      "name": "Iowa-Oto"
+    },
+    "ipi": {
+      "name": "Ipili"
+    },
+    "ipo": {
+      "name": "Ipiko"
+    },
+    "iqu": {
+      "name": "Iquito"
+    },
+    "iqw": {
+      "name": "Ikwo"
+    },
+    "ira": {
+      "name": "Iranian languages"
+    },
+    "ire": {
+      "name": "Iresim"
+    },
+    "irh": {
+      "name": "Irarutu"
+    },
+    "iri": {
+      "name": "Rigwe"
+    },
+    "irk": {
+      "name": "Iraqw"
+    },
+    "irn": {
+      "name": "Irántxe"
+    },
+    "iro": {
+      "name": "Iroquoian languages"
+    },
+    "irr": {
+      "name": "Ir"
+    },
+    "iru": {
+      "name": "Irula"
+    },
+    "irx": {
+      "name": "Kamberau"
+    },
+    "iry": {
+      "name": "Iraya"
+    },
+    "isa": {
+      "name": "Isabi"
+    },
+    "isc": {
+      "name": "Isconahua"
+    },
+    "isd": {
+      "name": "Isnag"
+    },
+    "ise": {
+      "name": "Italian Sign Language"
+    },
+    "isg": {
+      "name": "Irish Sign Language"
+    },
+    "ish": {
+      "name": "Esan"
+    },
+    "isi": {
+      "name": "Nkem-Nkum"
+    },
+    "isk": {
+      "name": "Ishkashimi"
+    },
+    "ism": {
+      "name": "Masimasi"
+    },
+    "isn": {
+      "name": "Isanzu"
+    },
+    "iso": {
+      "name": "Isoko"
+    },
+    "isr": {
+      "name": "Israeli Sign Language"
+    },
+    "ist": {
+      "name": "Istriot"
+    },
+    "isu": {
+      "name": "Isu (Menchum Division)"
+    },
+    "itb": {
+      "name": "Binongan Itneg"
+    },
+    "itc": {
+      "name": "Italic languages"
+    },
+    "itd": {
+      "name": "Southern Tidung"
+    },
+    "ite": {
+      "name": "Itene"
+    },
+    "iti": {
+      "name": "Inlaod Itneg"
+    },
+    "itk": {
+      "name": "Judeo-Italian"
+    },
+    "itl": {
+      "name": "Itelmen"
+    },
+    "itm": {
+      "name": "Itu Mbon Uzo"
+    },
+    "ito": {
+      "name": "Itonama"
+    },
+    "itr": {
+      "name": "Iteri"
+    },
+    "its": {
+      "name": "Isekiri"
+    },
+    "itt": {
+      "name": "Maeng Itneg"
+    },
+    "itv": {
+      "name": "Itawit"
+    },
+    "itw": {
+      "name": "Ito"
+    },
+    "itx": {
+      "name": "Itik"
+    },
+    "ity": {
+      "name": "Moyadan Itneg"
+    },
+    "itz": {
+      "name": "Itzá"
+    },
+    "ium": {
+      "name": "Iu Mien"
+    },
+    "ivb": {
+      "name": "Ibatan"
+    },
+    "ivv": {
+      "name": "Ivatan"
+    },
+    "iwk": {
+      "name": "I-Wak"
+    },
+    "iwm": {
+      "name": "Iwam"
+    },
+    "iwo": {
+      "name": "Iwur"
+    },
+    "iws": {
+      "name": "Sepik Iwam"
+    },
+    "ixc": {
+      "name": "Ixcatec"
+    },
+    "ixl": {
+      "name": "Ixil"
+    },
+    "iya": {
+      "name": "Iyayu"
+    },
+    "iyo": {
+      "name": "Mesaka"
+    },
+    "iyx": {
+      "name": "Yaka (Congo)"
+    },
+    "izh": {
+      "name": "Ingrian"
+    },
+    "izi": {
+      "name": "Izi-Ezaa-Ikwo-Mgbo"
+    },
+    "izr": {
+      "name": "Izere"
+    },
+    "izz": {
+      "name": "Izii"
+    },
+    "jaa": {
+      "name": "Jamamadí"
+    },
+    "jab": {
+      "name": "Hyam"
+    },
+    "jac": {
+      "name": "Popti'"
+    },
+    "jad": {
+      "name": "Jahanka"
+    },
+    "jae": {
+      "name": "Yabem"
+    },
+    "jaf": {
+      "name": "Jara"
+    },
+    "jah": {
+      "name": "Jah Hut"
+    },
+    "jaj": {
+      "name": "Zazao"
+    },
+    "jak": {
+      "name": "Jakun"
+    },
+    "jal": {
+      "name": "Yalahatan"
+    },
+    "jam": {
+      "name": "Jamaican Creole English"
+    },
+    "jan": {
+      "name": "Jandai"
+    },
+    "jao": {
+      "name": "Yanyuwa"
+    },
+    "jaq": {
+      "name": "Yaqay"
+    },
+    "jar": {
+      "name": "Jarawa (Nigeria)"
+    },
+    "jas": {
+      "name": "New Caledonian Javanese"
+    },
+    "jat": {
+      "name": "Jakati"
+    },
+    "jau": {
+      "name": "Yaur"
+    },
+    "jax": {
+      "name": "Jambi Malay"
+    },
+    "jay": {
+      "name": "Yan-nhangu"
+    },
+    "jaz": {
+      "name": "Jawe"
+    },
+    "jbe": {
+      "name": "Judeo-Berber"
+    },
+    "jbi": {
+      "name": "Badjiri"
+    },
+    "jbj": {
+      "name": "Arandai"
+    },
+    "jbk": {
+      "name": "Barikewa"
+    },
+    "jbn": {
+      "name": "Nafusi"
+    },
+    "jbo": {
+      "name": "Lojban"
+    },
+    "jbr": {
+      "name": "Jofotek-Bromnya"
+    },
+    "jbt": {
+      "name": "Jabutí"
+    },
+    "jbu": {
+      "name": "Jukun Takum"
+    },
+    "jbw": {
+      "name": "Yawijibaya"
+    },
+    "jcs": {
+      "name": "Jamaican Country Sign Language"
+    },
+    "jct": {
+      "name": "Krymchak"
+    },
+    "jda": {
+      "name": "Jad"
+    },
+    "jdg": {
+      "name": "Jadgali"
+    },
+    "jdt": {
+      "name": "Judeo-Tat"
+    },
+    "jeb": {
+      "name": "Jebero"
+    },
+    "jee": {
+      "name": "Jerung"
+    },
+    "jeg": {
+      "name": "Jeng"
+    },
+    "jeh": {
+      "name": "Jeh"
+    },
+    "jei": {
+      "name": "Yei"
+    },
+    "jek": {
+      "name": "Jeri Kuo"
+    },
+    "jel": {
+      "name": "Yelmek"
+    },
+    "jen": {
+      "name": "Dza"
+    },
+    "jer": {
+      "name": "Jere"
+    },
+    "jet": {
+      "name": "Manem"
+    },
+    "jeu": {
+      "name": "Jonkor Bourmataguil"
+    },
+    "jgb": {
+      "name": "Ngbee"
+    },
+    "jge": {
+      "name": "Judeo-Georgian"
+    },
+    "jgk": {
+      "name": "Gwak"
+    },
+    "jgo": {
+      "name": "Ngomba"
+    },
+    "jhi": {
+      "name": "Jehai"
+    },
+    "jhs": {
+      "name": "Jhankot Sign Language"
+    },
+    "jia": {
+      "name": "Jina"
+    },
+    "jib": {
+      "name": "Jibu"
+    },
+    "jic": {
+      "name": "Tol"
+    },
+    "jid": {
+      "name": "Bu"
+    },
+    "jie": {
+      "name": "Jilbe"
+    },
+    "jig": {
+      "name": "Djingili"
+    },
+    "jih": {
+      "name": "sTodsde"
+    },
+    "jii": {
+      "name": "Jiiddu"
+    },
+    "jil": {
+      "name": "Jilim"
+    },
+    "jim": {
+      "name": "Jimi (Cameroon)"
+    },
+    "jio": {
+      "name": "Jiamao"
+    },
+    "jiq": {
+      "name": "Guanyinqiao"
+    },
+    "jit": {
+      "name": "Jita"
+    },
+    "jiu": {
+      "name": "Youle Jinuo"
+    },
+    "jiv": {
+      "name": "Shuar"
+    },
+    "jiy": {
+      "name": "Buyuan Jinuo"
+    },
+    "jje": {
+      "name": "Jejueo"
+    },
+    "jjr": {
+      "name": "Bankal"
+    },
+    "jka": {
+      "name": "Kaera"
+    },
+    "jkm": {
+      "name": "Mobwa Karen"
+    },
+    "jko": {
+      "name": "Kubo"
+    },
+    "jkp": {
+      "name": "Paku Karen"
+    },
+    "jkr": {
+      "name": "Koro (India)"
+    },
+    "jku": {
+      "name": "Labir"
+    },
+    "jle": {
+      "name": "Ngile"
+    },
+    "jls": {
+      "name": "Jamaican Sign Language"
+    },
+    "jma": {
+      "name": "Dima"
+    },
+    "jmb": {
+      "name": "Zumbun"
+    },
+    "jmc": {
+      "name": "Machame"
+    },
+    "jmd": {
+      "name": "Yamdena"
+    },
+    "jmi": {
+      "name": "Jimi (Nigeria)"
+    },
+    "jml": {
+      "name": "Jumli"
+    },
+    "jmn": {
+      "name": "Makuri Naga"
+    },
+    "jmr": {
+      "name": "Kamara"
+    },
+    "jms": {
+      "name": "Mashi (Nigeria)"
+    },
+    "jmw": {
+      "name": "Mouwase"
+    },
+    "jmx": {
+      "name": "Western Juxtlahuaca Mixtec"
+    },
+    "jna": {
+      "name": "Jangshung"
+    },
+    "jnd": {
+      "name": "Jandavra"
+    },
+    "jng": {
+      "name": "Yangman"
+    },
+    "jni": {
+      "name": "Janji"
+    },
+    "jnj": {
+      "name": "Yemsa"
+    },
+    "jnl": {
+      "name": "Rawat"
+    },
+    "jns": {
+      "name": "Jaunsari"
+    },
+    "job": {
+      "name": "Joba"
+    },
+    "jod": {
+      "name": "Wojenaka"
+    },
+    "jog": {
+      "name": "Jogi"
+    },
+    "jor": {
+      "name": "Jorá"
+    },
+    "jos": {
+      "name": "Jordanian Sign Language"
+    },
+    "jow": {
+      "name": "Jowulu"
+    },
+    "jpa": {
+      "name": "Jewish Palestinian Aramaic"
+    },
+    "jpr": {
+      "name": "Judeo-Persian"
+    },
+    "jpx": {
+      "name": "Japanese (family)"
+    },
+    "jqr": {
+      "name": "Jaqaru"
+    },
+    "jra": {
+      "name": "Jarai"
+    },
+    "jrb": {
+      "name": "Judeo-Arabic"
+    },
+    "jrr": {
+      "name": "Jiru"
+    },
+    "jrt": {
+      "name": "Jorto"
+    },
+    "jru": {
+      "name": "Japrería"
+    },
+    "jsl": {
+      "name": "Japanese Sign Language"
+    },
+    "jua": {
+      "name": "Júma"
+    },
+    "jub": {
+      "name": "Wannu"
+    },
+    "juc": {
+      "name": "Jurchen"
+    },
+    "jud": {
+      "name": "Worodougou"
+    },
+    "juh": {
+      "name": "Hõne"
+    },
+    "jui": {
+      "name": "Ngadjuri"
+    },
+    "juk": {
+      "name": "Wapan"
+    },
+    "jul": {
+      "name": "Jirel"
+    },
+    "jum": {
+      "name": "Jumjum"
+    },
+    "jun": {
+      "name": "Juang"
+    },
+    "juo": {
+      "name": "Jiba"
+    },
+    "jup": {
+      "name": "Hupdë"
+    },
+    "jur": {
+      "name": "Jurúna"
+    },
+    "jus": {
+      "name": "Jumla Sign Language"
+    },
+    "jut": {
+      "name": "Jutish"
+    },
+    "juu": {
+      "name": "Ju"
+    },
+    "juw": {
+      "name": "Wãpha"
+    },
+    "juy": {
+      "name": "Juray"
+    },
+    "jvd": {
+      "name": "Javindo"
+    },
+    "jvn": {
+      "name": "Caribbean Javanese"
+    },
+    "jwi": {
+      "name": "Jwira-Pepesa"
+    },
+    "jya": {
+      "name": "Jiarong"
+    },
+    "jye": {
+      "name": "Judeo-Yemeni Arabic"
+    },
+    "jyy": {
+      "name": "Jaya"
+    },
+    "kaa": {
+      "name": "Kara-Kalpak"
+    },
+    "kab": {
+      "name": "Kabyle"
+    },
+    "kac": {
+      "name": "Kachin"
+    },
+    "kad": {
+      "name": "Adara"
+    },
+    "kae": {
+      "name": "Ketangalan"
+    },
+    "kaf": {
+      "name": "Katso"
+    },
+    "kag": {
+      "name": "Kajaman"
+    },
+    "kah": {
+      "name": "Kara (Central African Republic)"
+    },
+    "kai": {
+      "name": "Karekare"
+    },
+    "kaj": {
+      "name": "Jju"
+    },
+    "kak": {
+      "name": "Kalanguya"
+    },
+    "kam": {
+      "name": "Kamba (Kenya)"
+    },
+    "kao": {
+      "name": "Xaasongaxango"
+    },
+    "kap": {
+      "name": "Bezhta"
+    },
+    "kaq": {
+      "name": "Capanahua"
+    },
+    "kar": {
+      "name": "Karen languages"
+    },
+    "kav": {
+      "name": "Katukína"
+    },
+    "kaw": {
+      "name": "Kawi"
+    },
+    "kax": {
+      "name": "Kao"
+    },
+    "kay": {
+      "name": "Kamayurá"
+    },
+    "kba": {
+      "name": "Kalarko"
+    },
+    "kbb": {
+      "name": "Kaxuiâna"
+    },
+    "kbc": {
+      "name": "Kadiwéu"
+    },
+    "kbd": {
+      "name": "Kabardian"
+    },
+    "kbe": {
+      "name": "Kanju"
+    },
+    "kbf": {
+      "name": "Kakauhua"
+    },
+    "kbg": {
+      "name": "Khamba"
+    },
+    "kbh": {
+      "name": "Camsá"
+    },
+    "kbi": {
+      "name": "Kaptiau"
+    },
+    "kbj": {
+      "name": "Kari"
+    },
+    "kbk": {
+      "name": "Grass Koiari"
+    },
+    "kbl": {
+      "name": "Kanembu"
+    },
+    "kbm": {
+      "name": "Iwal"
+    },
+    "kbn": {
+      "name": "Kare (Central African Republic)"
+    },
+    "kbo": {
+      "name": "Keliko"
+    },
+    "kbp": {
+      "name": "Kabiyè"
+    },
+    "kbq": {
+      "name": "Kamano"
+    },
+    "kbr": {
+      "name": "Kafa"
+    },
+    "kbs": {
+      "name": "Kande"
+    },
+    "kbt": {
+      "name": "Abadi"
+    },
+    "kbu": {
+      "name": "Kabutra"
+    },
+    "kbv": {
+      "name": "Dera (Indonesia)"
+    },
+    "kbw": {
+      "name": "Kaiep"
+    },
+    "kbx": {
+      "name": "Ap Ma"
+    },
+    "kby": {
+      "name": "Manga Kanuri"
+    },
+    "kbz": {
+      "name": "Duhwa"
+    },
+    "kca": {
+      "name": "Khanty"
+    },
+    "kcb": {
+      "name": "Kawacha"
+    },
+    "kcc": {
+      "name": "Lubila"
+    },
+    "kcd": {
+      "name": "Ngkâlmpw Kanum"
+    },
+    "kce": {
+      "name": "Kaivi"
+    },
+    "kcf": {
+      "name": "Ukaan"
+    },
+    "kcg": {
+      "name": "Tyap"
+    },
+    "kch": {
+      "name": "Vono"
+    },
+    "kci": {
+      "name": "Kamantan"
+    },
+    "kcj": {
+      "name": "Kobiana"
+    },
+    "kck": {
+      "name": "Kalanga"
+    },
+    "kcl": {
+      "name": "Kela (Papua New Guinea)"
+    },
+    "kcm": {
+      "name": "Gula (Central African Republic)"
+    },
+    "kcn": {
+      "name": "Nubi"
+    },
+    "kco": {
+      "name": "Kinalakna"
+    },
+    "kcp": {
+      "name": "Kanga"
+    },
+    "kcq": {
+      "name": "Kamo"
+    },
+    "kcr": {
+      "name": "Katla"
+    },
+    "kcs": {
+      "name": "Koenoem"
+    },
+    "kct": {
+      "name": "Kaian"
+    },
+    "kcu": {
+      "name": "Kami (Tanzania)"
+    },
+    "kcv": {
+      "name": "Kete"
+    },
+    "kcw": {
+      "name": "Kabwari"
+    },
+    "kcx": {
+      "name": "Kachama-Ganjule"
+    },
+    "kcy": {
+      "name": "Korandje"
+    },
+    "kcz": {
+      "name": "Konongo"
+    },
+    "kda": {
+      "name": "Worimi"
+    },
+    "kdc": {
+      "name": "Kutu"
+    },
+    "kdd": {
+      "name": "Yankunytjatjara"
+    },
+    "kde": {
+      "name": "Makonde"
+    },
+    "kdf": {
+      "name": "Mamusi"
+    },
+    "kdg": {
+      "name": "Seba"
+    },
+    "kdh": {
+      "name": "Tem"
+    },
+    "kdi": {
+      "name": "Kumam"
+    },
+    "kdj": {
+      "name": "Karamojong"
+    },
+    "kdk": {
+      "name": "Numèè"
+    },
+    "kdl": {
+      "name": "Tsikimba"
+    },
+    "kdm": {
+      "name": "Kagoma"
+    },
+    "kdn": {
+      "name": "Kunda"
+    },
+    "kdo": {
+      "name": "Kordofanian languages"
+    },
+    "kdp": {
+      "name": "Kaningdon-Nindem"
+    },
+    "kdq": {
+      "name": "Koch"
+    },
+    "kdr": {
+      "name": "Karaim"
+    },
+    "kdt": {
+      "name": "Kuy"
+    },
+    "kdu": {
+      "name": "Kadaru"
+    },
+    "kdv": {
+      "name": "Kado"
+    },
+    "kdw": {
+      "name": "Koneraw"
+    },
+    "kdx": {
+      "name": "Kam"
+    },
+    "kdy": {
+      "name": "Keder"
+    },
+    "kdz": {
+      "name": "Kwaja"
+    },
+    "kea": {
+      "name": "Kabuverdianu"
+    },
+    "keb": {
+      "name": "Kélé"
+    },
+    "kec": {
+      "name": "Keiga"
+    },
+    "ked": {
+      "name": "Kerewe"
+    },
+    "kee": {
+      "name": "Eastern Keres"
+    },
+    "kef": {
+      "name": "Kpessi"
+    },
+    "keg": {
+      "name": "Tese"
+    },
+    "keh": {
+      "name": "Keak"
+    },
+    "kei": {
+      "name": "Kei"
+    },
+    "kej": {
+      "name": "Kadar"
+    },
+    "kek": {
+      "name": "Kekchí"
+    },
+    "kel": {
+      "name": "Kela (Democratic Republic of Congo)"
+    },
+    "kem": {
+      "name": "Kemak"
+    },
+    "ken": {
+      "name": "Kenyang"
+    },
+    "keo": {
+      "name": "Kakwa"
+    },
+    "kep": {
+      "name": "Kaikadi"
+    },
+    "keq": {
+      "name": "Kamar"
+    },
+    "ker": {
+      "name": "Kera"
+    },
+    "kes": {
+      "name": "Kugbo"
+    },
+    "ket": {
+      "name": "Ket"
+    },
+    "keu": {
+      "name": "Akebu"
+    },
+    "kev": {
+      "name": "Kanikkaran"
+    },
+    "kew": {
+      "name": "West Kewa"
+    },
+    "kex": {
+      "name": "Kukna"
+    },
+    "key": {
+      "name": "Kupia"
+    },
+    "kez": {
+      "name": "Kukele"
+    },
+    "kfa": {
+      "name": "Kodava"
+    },
+    "kfb": {
+      "name": "Northwestern Kolami"
+    },
+    "kfc": {
+      "name": "Konda-Dora"
+    },
+    "kfd": {
+      "name": "Korra Koraga"
+    },
+    "kfe": {
+      "name": "Kota (India)"
+    },
+    "kff": {
+      "name": "Koya"
+    },
+    "kfg": {
+      "name": "Kudiya"
+    },
+    "kfh": {
+      "name": "Kurichiya"
+    },
+    "kfi": {
+      "name": "Kannada Kurumba"
+    },
+    "kfj": {
+      "name": "Kemiehua"
+    },
+    "kfk": {
+      "name": "Kinnauri"
+    },
+    "kfl": {
+      "name": "Kung"
+    },
+    "kfm": {
+      "name": "Khunsari"
+    },
+    "kfn": {
+      "name": "Kuk"
+    },
+    "kfo": {
+      "name": "Koro (Côte d'Ivoire)"
+    },
+    "kfp": {
+      "name": "Korwa"
+    },
+    "kfq": {
+      "name": "Korku"
+    },
+    "kfr": {
+      "name": "Kachhi"
+    },
+    "kfs": {
+      "name": "Bilaspuri"
+    },
+    "kft": {
+      "name": "Kanjari"
+    },
+    "kfu": {
+      "name": "Katkari"
+    },
+    "kfv": {
+      "name": "Kurmukar"
+    },
+    "kfw": {
+      "name": "Kharam Naga"
+    },
+    "kfx": {
+      "name": "Kullu Pahari"
+    },
+    "kfy": {
+      "name": "Kumaoni"
+    },
+    "kfz": {
+      "name": "Koromfé"
+    },
+    "kga": {
+      "name": "Koyaga"
+    },
+    "kgb": {
+      "name": "Kawe"
+    },
+    "kgc": {
+      "name": "Kasseng"
+    },
+    "kgd": {
+      "name": "Kataang"
+    },
+    "kge": {
+      "name": "Komering"
+    },
+    "kgf": {
+      "name": "Kube"
+    },
+    "kgg": {
+      "name": "Kusunda"
+    },
+    "kgh": {
+      "name": "Upper Tanudan Kalinga"
+    },
+    "kgi": {
+      "name": "Selangor Sign Language"
+    },
+    "kgj": {
+      "name": "Gamale Kham"
+    },
+    "kgk": {
+      "name": "Kaiwá"
+    },
+    "kgl": {
+      "name": "Kunggari"
+    },
+    "kgm": {
+      "name": "Karipúna"
+    },
+    "kgn": {
+      "name": "Karingani"
+    },
+    "kgo": {
+      "name": "Krongo"
+    },
+    "kgp": {
+      "name": "Kaingang"
+    },
+    "kgq": {
+      "name": "Kamoro"
+    },
+    "kgr": {
+      "name": "Abun"
+    },
+    "kgs": {
+      "name": "Kumbainggar"
+    },
+    "kgt": {
+      "name": "Somyev"
+    },
+    "kgu": {
+      "name": "Kobol"
+    },
+    "kgv": {
+      "name": "Karas"
+    },
+    "kgw": {
+      "name": "Karon Dori"
+    },
+    "kgx": {
+      "name": "Kamaru"
+    },
+    "kgy": {
+      "name": "Kyerung"
+    },
+    "kha": {
+      "name": "Khasi"
+    },
+    "khb": {
+      "name": "Lü"
+    },
+    "khc": {
+      "name": "Tukang Besi North"
+    },
+    "khd": {
+      "name": "Bädi Kanum"
+    },
+    "khe": {
+      "name": "Korowai"
+    },
+    "khf": {
+      "name": "Khuen"
+    },
+    "khg": {
+      "name": "Khams Tibetan"
+    },
+    "khh": {
+      "name": "Kehu"
+    },
+    "khi": {
+      "name": "Khoisan languages"
+    },
+    "khj": {
+      "name": "Kuturmi"
+    },
+    "khk": {
+      "name": "Halh Mongolian"
+    },
+    "khl": {
+      "name": "Lusi"
+    },
+    "khn": {
+      "name": "Khandesi"
+    },
+    "kho": {
+      "name": "Khotanese"
+    },
+    "khp": {
+      "name": "Kapori"
+    },
+    "khq": {
+      "name": "Koyra Chiini Songhay"
+    },
+    "khr": {
+      "name": "Kharia"
+    },
+    "khs": {
+      "name": "Kasua"
+    },
+    "kht": {
+      "name": "Khamti"
+    },
+    "khu": {
+      "name": "Nkhumbi"
+    },
+    "khv": {
+      "name": "Khvarshi"
+    },
+    "khw": {
+      "name": "Khowar"
+    },
+    "khx": {
+      "name": "Kanu"
+    },
+    "khy": {
+      "name": "Kele (Democratic Republic of Congo)"
+    },
+    "khz": {
+      "name": "Keapara"
+    },
+    "kia": {
+      "name": "Kim"
+    },
+    "kib": {
+      "name": "Koalib"
+    },
+    "kic": {
+      "name": "Kickapoo"
+    },
+    "kid": {
+      "name": "Koshin"
+    },
+    "kie": {
+      "name": "Kibet"
+    },
+    "kif": {
+      "name": "Eastern Parbate Kham"
+    },
+    "kig": {
+      "name": "Kimaama"
+    },
+    "kih": {
+      "name": "Kilmeri"
+    },
+    "kii": {
+      "name": "Kitsai"
+    },
+    "kij": {
+      "name": "Kilivila"
+    },
+    "kil": {
+      "name": "Kariya"
+    },
+    "kim": {
+      "name": "Karagas"
+    },
+    "kio": {
+      "name": "Kiowa"
+    },
+    "kip": {
+      "name": "Sheshi Kham"
+    },
+    "kiq": {
+      "name": "Kosadle"
+    },
+    "kis": {
+      "name": "Kis"
+    },
+    "kit": {
+      "name": "Agob"
+    },
+    "kiu": {
+      "name": "Kirmanjki (individual language)"
+    },
+    "kiv": {
+      "name": "Kimbu"
+    },
+    "kiw": {
+      "name": "Northeast Kiwai"
+    },
+    "kix": {
+      "name": "Khiamniungan Naga"
+    },
+    "kiy": {
+      "name": "Kirikiri"
+    },
+    "kiz": {
+      "name": "Kisi"
+    },
+    "kja": {
+      "name": "Mlap"
+    },
+    "kjb": {
+      "name": "Q'anjob'al"
+    },
+    "kjc": {
+      "name": "Coastal Konjo"
+    },
+    "kjd": {
+      "name": "Southern Kiwai"
+    },
+    "kje": {
+      "name": "Kisar"
+    },
+    "kjf": {
+      "name": "Khalaj"
+    },
+    "kjg": {
+      "name": "Khmu"
+    },
+    "kjh": {
+      "name": "Khakas"
+    },
+    "kji": {
+      "name": "Zabana"
+    },
+    "kjj": {
+      "name": "Khinalugh"
+    },
+    "kjk": {
+      "name": "Highland Konjo"
+    },
+    "kjl": {
+      "name": "Western Parbate Kham"
+    },
+    "kjm": {
+      "name": "Kháng"
+    },
+    "kjn": {
+      "name": "Kunjen"
+    },
+    "kjo": {
+      "name": "Harijan Kinnauri"
+    },
+    "kjp": {
+      "name": "Pwo Eastern Karen"
+    },
+    "kjq": {
+      "name": "Western Keres"
+    },
+    "kjr": {
+      "name": "Kurudu"
+    },
+    "kjs": {
+      "name": "East Kewa"
+    },
+    "kjt": {
+      "name": "Phrae Pwo Karen"
+    },
+    "kju": {
+      "name": "Kashaya"
+    },
+    "kjv": {
+      "name": "Kaikavian Literary Language"
+    },
+    "kjx": {
+      "name": "Ramopa"
+    },
+    "kjy": {
+      "name": "Erave"
+    },
+    "kjz": {
+      "name": "Bumthangkha"
+    },
+    "kka": {
+      "name": "Kakanda"
+    },
+    "kkb": {
+      "name": "Kwerisa"
+    },
+    "kkc": {
+      "name": "Odoodee"
+    },
+    "kkd": {
+      "name": "Kinuku"
+    },
+    "kke": {
+      "name": "Kakabe"
+    },
+    "kkf": {
+      "name": "Kalaktang Monpa"
+    },
+    "kkg": {
+      "name": "Mabaka Valley Kalinga"
+    },
+    "kkh": {
+      "name": "Khün"
+    },
+    "kki": {
+      "name": "Kagulu"
+    },
+    "kkj": {
+      "name": "Kako"
+    },
+    "kkk": {
+      "name": "Kokota"
+    },
+    "kkl": {
+      "name": "Kosarek Yale"
+    },
+    "kkm": {
+      "name": "Kiong"
+    },
+    "kkn": {
+      "name": "Kon Keu"
+    },
+    "kko": {
+      "name": "Karko"
+    },
+    "kkp": {
+      "name": "Gugubera"
+    },
+    "kkq": {
+      "name": "Kaiku"
+    },
+    "kkr": {
+      "name": "Kir-Balar"
+    },
+    "kks": {
+      "name": "Giiwo"
+    },
+    "kkt": {
+      "name": "Koi"
+    },
+    "kku": {
+      "name": "Tumi"
+    },
+    "kkv": {
+      "name": "Kangean"
+    },
+    "kkw": {
+      "name": "Teke-Kukuya"
+    },
+    "kkx": {
+      "name": "Kohin"
+    },
+    "kky": {
+      "name": "Guguyimidjir"
+    },
+    "kkz": {
+      "name": "Kaska"
+    },
+    "kla": {
+      "name": "Klamath-Modoc"
+    },
+    "klb": {
+      "name": "Kiliwa"
+    },
+    "klc": {
+      "name": "Kolbila"
+    },
+    "kld": {
+      "name": "Gamilaraay"
+    },
+    "kle": {
+      "name": "Kulung (Nepal)"
+    },
+    "klf": {
+      "name": "Kendeje"
+    },
+    "klg": {
+      "name": "Tagakaulo"
+    },
+    "klh": {
+      "name": "Weliki"
+    },
+    "kli": {
+      "name": "Kalumpang"
+    },
+    "klj": {
+      "name": "Turkic Khalaj"
+    },
+    "klk": {
+      "name": "Kono (Nigeria)"
+    },
+    "kll": {
+      "name": "Kagan Kalagan"
+    },
+    "klm": {
+      "name": "Migum"
+    },
+    "kln": {
+      "name": "Kalenjin"
+    },
+    "klo": {
+      "name": "Kapya"
+    },
+    "klp": {
+      "name": "Kamasa"
+    },
+    "klq": {
+      "name": "Rumu"
+    },
+    "klr": {
+      "name": "Khaling"
+    },
+    "kls": {
+      "name": "Kalasha"
+    },
+    "klt": {
+      "name": "Nukna"
+    },
+    "klu": {
+      "name": "Klao"
+    },
+    "klv": {
+      "name": "Maskelynes"
+    },
+    "klw": {
+      "name": "Tado"
+    },
+    "klx": {
+      "name": "Koluwawa"
+    },
+    "kly": {
+      "name": "Kalao"
+    },
+    "klz": {
+      "name": "Kabola"
+    },
+    "kma": {
+      "name": "Konni"
+    },
+    "kmb": {
+      "name": "Kimbundu"
+    },
+    "kmc": {
+      "name": "Southern Dong"
+    },
+    "kmd": {
+      "name": "Majukayang Kalinga"
+    },
+    "kme": {
+      "name": "Bakole"
+    },
+    "kmf": {
+      "name": "Kare (Papua New Guinea)"
+    },
+    "kmg": {
+      "name": "Kâte"
+    },
+    "kmh": {
+      "name": "Kalam"
+    },
+    "kmi": {
+      "name": "Kami (Nigeria)"
+    },
+    "kmj": {
+      "name": "Kumarbhag Paharia"
+    },
+    "kmk": {
+      "name": "Limos Kalinga"
+    },
+    "kml": {
+      "name": "Tanudan Kalinga"
+    },
+    "kmm": {
+      "name": "Kom (India)"
+    },
+    "kmn": {
+      "name": "Awtuw"
+    },
+    "kmo": {
+      "name": "Kwoma"
+    },
+    "kmp": {
+      "name": "Gimme"
+    },
+    "kmq": {
+      "name": "Kwama"
+    },
+    "kmr": {
+      "name": "Northern Kurdish"
+    },
+    "kms": {
+      "name": "Kamasau"
+    },
+    "kmt": {
+      "name": "Kemtuik"
+    },
+    "kmu": {
+      "name": "Kanite"
+    },
+    "kmv": {
+      "name": "Karipúna Creole French"
+    },
+    "kmw": {
+      "name": "Komo (Democratic Republic of Congo)"
+    },
+    "kmx": {
+      "name": "Waboda"
+    },
+    "kmy": {
+      "name": "Koma"
+    },
+    "kmz": {
+      "name": "Khorasani Turkish"
+    },
+    "kna": {
+      "name": "Dera (Nigeria)"
+    },
+    "knb": {
+      "name": "Lubuagan Kalinga"
+    },
+    "knc": {
+      "name": "Central Kanuri"
+    },
+    "knd": {
+      "name": "Konda"
+    },
+    "kne": {
+      "name": "Kankanaey"
+    },
+    "knf": {
+      "name": "Mankanya"
+    },
+    "kng": {
+      "name": "Koongo"
+    },
+    "kni": {
+      "name": "Kanufi"
+    },
+    "knj": {
+      "name": "Western Kanjobal"
+    },
+    "knk": {
+      "name": "Kuranko"
+    },
+    "knl": {
+      "name": "Keninjal"
+    },
+    "knm": {
+      "name": "Kanamarí"
+    },
+    "knn": {
+      "name": "Konkani (individual language)"
+    },
+    "kno": {
+      "name": "Kono (Sierra Leone)"
+    },
+    "knp": {
+      "name": "Kwanja"
+    },
+    "knq": {
+      "name": "Kintaq"
+    },
+    "knr": {
+      "name": "Kaningra"
+    },
+    "kns": {
+      "name": "Kensiu"
+    },
+    "knt": {
+      "name": "Panoan Katukína"
+    },
+    "knu": {
+      "name": "Kono (Guinea)"
+    },
+    "knv": {
+      "name": "Tabo"
+    },
+    "knw": {
+      "name": "Kung-Ekoka"
+    },
+    "knx": {
+      "name": "Kendayan"
+    },
+    "kny": {
+      "name": "Kanyok"
+    },
+    "knz": {
+      "name": "Kalamsé"
+    },
+    "koa": {
+      "name": "Konomala"
+    },
+    "koc": {
+      "name": "Kpati"
+    },
+    "kod": {
+      "name": "Kodi"
+    },
+    "koe": {
+      "name": "Kacipo-Balesi"
+    },
+    "kof": {
+      "name": "Kubi"
+    },
+    "kog": {
+      "name": "Cogui"
+    },
+    "koh": {
+      "name": "Koyo"
+    },
+    "koi": {
+      "name": "Komi-Permyak"
+    },
+    "koj": {
+      "name": "Sara Dunjo"
+    },
+    "kok": {
+      "name": "Konkani (macrolanguage)"
+    },
+    "kol": {
+      "name": "Kol (Papua New Guinea)"
+    },
+    "koo": {
+      "name": "Konzo"
+    },
+    "kop": {
+      "name": "Waube"
+    },
+    "koq": {
+      "name": "Kota (Gabon)"
+    },
+    "kos": {
+      "name": "Kosraean"
+    },
+    "kot": {
+      "name": "Lagwan"
+    },
+    "kou": {
+      "name": "Koke"
+    },
+    "kov": {
+      "name": "Kudu-Camo"
+    },
+    "kow": {
+      "name": "Kugama"
+    },
+    "kox": {
+      "name": "Coxima"
+    },
+    "koy": {
+      "name": "Koyukon"
+    },
+    "koz": {
+      "name": "Korak"
+    },
+    "kpa": {
+      "name": "Kutto"
+    },
+    "kpb": {
+      "name": "Mullu Kurumba"
+    },
+    "kpc": {
+      "name": "Curripaco"
+    },
+    "kpd": {
+      "name": "Koba"
+    },
+    "kpe": {
+      "name": "Kpelle"
+    },
+    "kpf": {
+      "name": "Komba"
+    },
+    "kpg": {
+      "name": "Kapingamarangi"
+    },
+    "kph": {
+      "name": "Kplang"
+    },
+    "kpi": {
+      "name": "Kofei"
+    },
+    "kpj": {
+      "name": "Karajá"
+    },
+    "kpk": {
+      "name": "Kpan"
+    },
+    "kpl": {
+      "name": "Kpala"
+    },
+    "kpm": {
+      "name": "Koho"
+    },
+    "kpn": {
+      "name": "Kepkiriwát"
+    },
+    "kpo": {
+      "name": "Ikposo"
+    },
+    "kpp": {
+      "name": "Paku Karen"
+    },
+    "kpq": {
+      "name": "Korupun-Sela"
+    },
+    "kpr": {
+      "name": "Korafe-Yegha"
+    },
+    "kps": {
+      "name": "Tehit"
+    },
+    "kpt": {
+      "name": "Karata"
+    },
+    "kpu": {
+      "name": "Kafoa"
+    },
+    "kpv": {
+      "name": "Komi-Zyrian"
+    },
+    "kpw": {
+      "name": "Kobon"
+    },
+    "kpx": {
+      "name": "Mountain Koiali"
+    },
+    "kpy": {
+      "name": "Koryak"
+    },
+    "kpz": {
+      "name": "Kupsabiny"
+    },
+    "kqa": {
+      "name": "Mum"
+    },
+    "kqb": {
+      "name": "Kovai"
+    },
+    "kqc": {
+      "name": "Doromu-Koki"
+    },
+    "kqd": {
+      "name": "Koy Sanjaq Surat"
+    },
+    "kqe": {
+      "name": "Kalagan"
+    },
+    "kqf": {
+      "name": "Kakabai"
+    },
+    "kqg": {
+      "name": "Khe"
+    },
+    "kqh": {
+      "name": "Kisankasa"
+    },
+    "kqi": {
+      "name": "Koitabu"
+    },
+    "kqj": {
+      "name": "Koromira"
+    },
+    "kqk": {
+      "name": "Kotafon Gbe"
+    },
+    "kql": {
+      "name": "Kyenele"
+    },
+    "kqm": {
+      "name": "Khisa"
+    },
+    "kqn": {
+      "name": "Kaonde"
+    },
+    "kqo": {
+      "name": "Eastern Krahn"
+    },
+    "kqp": {
+      "name": "Kimré"
+    },
+    "kqq": {
+      "name": "Krenak"
+    },
+    "kqr": {
+      "name": "Kimaragang"
+    },
+    "kqs": {
+      "name": "Northern Kissi"
+    },
+    "kqt": {
+      "name": "Klias River Kadazan"
+    },
+    "kqu": {
+      "name": "Seroa"
+    },
+    "kqv": {
+      "name": "Okolod"
+    },
+    "kqw": {
+      "name": "Kandas"
+    },
+    "kqx": {
+      "name": "Mser"
+    },
+    "kqy": {
+      "name": "Koorete"
+    },
+    "kqz": {
+      "name": "Korana"
+    },
+    "kra": {
+      "name": "Kumhali"
+    },
+    "krb": {
+      "name": "Karkin"
+    },
+    "krc": {
+      "name": "Karachay-Balkar"
+    },
+    "krd": {
+      "name": "Kairui-Midiki"
+    },
+    "kre": {
+      "name": "Panará"
+    },
+    "krf": {
+      "name": "Koro (Vanuatu)"
+    },
+    "krh": {
+      "name": "Kurama"
+    },
+    "kri": {
+      "name": "Krio"
+    },
+    "krj": {
+      "name": "Kinaray-A"
+    },
+    "krk": {
+      "name": "Kerek"
+    },
+    "krl": {
+      "name": "Karelian"
+    },
+    "krm": {
+      "name": "Krim"
+    },
+    "krn": {
+      "name": "Sapo"
+    },
+    "kro": {
+      "name": "Kru languages"
+    },
+    "krp": {
+      "name": "Korop"
+    },
+    "krr": {
+      "name": "Krung"
+    },
+    "krs": {
+      "name": "Gbaya (Sudan)"
+    },
+    "krt": {
+      "name": "Tumari Kanuri"
+    },
+    "kru": {
+      "name": "Kurukh"
+    },
+    "krv": {
+      "name": "Kavet"
+    },
+    "krw": {
+      "name": "Western Krahn"
+    },
+    "krx": {
+      "name": "Karon"
+    },
+    "kry": {
+      "name": "Kryts"
+    },
+    "krz": {
+      "name": "Sota Kanum"
+    },
+    "ksa": {
+      "name": "Shuwa-Zamani"
+    },
+    "ksb": {
+      "name": "Shambala"
+    },
+    "ksc": {
+      "name": "Southern Kalinga"
+    },
+    "ksd": {
+      "name": "Kuanua"
+    },
+    "kse": {
+      "name": "Kuni"
+    },
+    "ksf": {
+      "name": "Bafia"
+    },
+    "ksg": {
+      "name": "Kusaghe"
+    },
+    "ksh": {
+      "name": "Kölsch"
+    },
+    "ksi": {
+      "name": "Krisa"
+    },
+    "ksj": {
+      "name": "Uare"
+    },
+    "ksk": {
+      "name": "Kansa"
+    },
+    "ksl": {
+      "name": "Kumalu"
+    },
+    "ksm": {
+      "name": "Kumba"
+    },
+    "ksn": {
+      "name": "Kasiguranin"
+    },
+    "kso": {
+      "name": "Kofa"
+    },
+    "ksp": {
+      "name": "Kaba"
+    },
+    "ksq": {
+      "name": "Kwaami"
+    },
+    "ksr": {
+      "name": "Borong"
+    },
+    "kss": {
+      "name": "Southern Kisi"
+    },
+    "kst": {
+      "name": "Winyé"
+    },
+    "ksu": {
+      "name": "Khamyang"
+    },
+    "ksv": {
+      "name": "Kusu"
+    },
+    "ksw": {
+      "name": "S'gaw Karen"
+    },
+    "ksx": {
+      "name": "Kedang"
+    },
+    "ksy": {
+      "name": "Kharia Thar"
+    },
+    "ksz": {
+      "name": "Kodaku"
+    },
+    "kta": {
+      "name": "Katua"
+    },
+    "ktb": {
+      "name": "Kambaata"
+    },
+    "ktc": {
+      "name": "Kholok"
+    },
+    "ktd": {
+      "name": "Kokata"
+    },
+    "kte": {
+      "name": "Nubri"
+    },
+    "ktf": {
+      "name": "Kwami"
+    },
+    "ktg": {
+      "name": "Kalkutung"
+    },
+    "kth": {
+      "name": "Karanga"
+    },
+    "kti": {
+      "name": "North Muyu"
+    },
+    "ktj": {
+      "name": "Plapo Krumen"
+    },
+    "ktk": {
+      "name": "Kaniet"
+    },
+    "ktl": {
+      "name": "Koroshi"
+    },
+    "ktm": {
+      "name": "Kurti"
+    },
+    "ktn": {
+      "name": "Karitiâna"
+    },
+    "kto": {
+      "name": "Kuot"
+    },
+    "ktp": {
+      "name": "Kaduo"
+    },
+    "ktq": {
+      "name": "Katabaga"
+    },
+    "ktr": {
+      "name": "Kota Marudu Tinagas"
+    },
+    "kts": {
+      "name": "South Muyu"
+    },
+    "ktt": {
+      "name": "Ketum"
+    },
+    "ktu": {
+      "name": "Kituba (Democratic Republic of Congo)"
+    },
+    "ktv": {
+      "name": "Eastern Katu"
+    },
+    "ktw": {
+      "name": "Kato"
+    },
+    "ktx": {
+      "name": "Kaxararí"
+    },
+    "kty": {
+      "name": "Kango (Bas-Uélé District)"
+    },
+    "ktz": {
+      "name": "Ju/'hoan"
+    },
+    "kub": {
+      "name": "Kutep"
+    },
+    "kuc": {
+      "name": "Kwinsu"
+    },
+    "kud": {
+      "name": "'Auhelawa"
+    },
+    "kue": {
+      "name": "Kuman (Papua New Guinea)"
+    },
+    "kuf": {
+      "name": "Western Katu"
+    },
+    "kug": {
+      "name": "Kupa"
+    },
+    "kuh": {
+      "name": "Kushi"
+    },
+    "kui": {
+      "name": "Kuikúro-Kalapálo"
+    },
+    "kuj": {
+      "name": "Kuria"
+    },
+    "kuk": {
+      "name": "Kepo'"
+    },
+    "kul": {
+      "name": "Kulere"
+    },
+    "kum": {
+      "name": "Kumyk"
+    },
+    "kun": {
+      "name": "Kunama"
+    },
+    "kuo": {
+      "name": "Kumukio"
+    },
+    "kup": {
+      "name": "Kunimaipa"
+    },
+    "kuq": {
+      "name": "Karipuna"
+    },
+    "kus": {
+      "name": "Kusaal"
+    },
+    "kut": {
+      "name": "Kutenai"
+    },
+    "kuu": {
+      "name": "Upper Kuskokwim"
+    },
+    "kuv": {
+      "name": "Kur"
+    },
+    "kuw": {
+      "name": "Kpagua"
+    },
+    "kux": {
+      "name": "Kukatja"
+    },
+    "kuy": {
+      "name": "Kuuku-Ya'u"
+    },
+    "kuz": {
+      "name": "Kunza"
+    },
+    "kva": {
+      "name": "Bagvalal"
+    },
+    "kvb": {
+      "name": "Kubu"
+    },
+    "kvc": {
+      "name": "Kove"
+    },
+    "kvd": {
+      "name": "Kui (Indonesia)"
+    },
+    "kve": {
+      "name": "Kalabakan"
+    },
+    "kvf": {
+      "name": "Kabalai"
+    },
+    "kvg": {
+      "name": "Kuni-Boazi"
+    },
+    "kvh": {
+      "name": "Komodo"
+    },
+    "kvi": {
+      "name": "Kwang"
+    },
+    "kvj": {
+      "name": "Psikye"
+    },
+    "kvk": {
+      "name": "Korean Sign Language"
+    },
+    "kvl": {
+      "name": "Kayaw"
+    },
+    "kvm": {
+      "name": "Kendem"
+    },
+    "kvn": {
+      "name": "Border Kuna"
+    },
+    "kvo": {
+      "name": "Dobel"
+    },
+    "kvp": {
+      "name": "Kompane"
+    },
+    "kvq": {
+      "name": "Geba Karen"
+    },
+    "kvr": {
+      "name": "Kerinci"
+    },
+    "kvs": {
+      "name": "Kunggara"
+    },
+    "kvt": {
+      "name": "Lahta Karen"
+    },
+    "kvu": {
+      "name": "Yinbaw Karen"
+    },
+    "kvv": {
+      "name": "Kola"
+    },
+    "kvw": {
+      "name": "Wersing"
+    },
+    "kvx": {
+      "name": "Parkari Koli"
+    },
+    "kvy": {
+      "name": "Yintale Karen"
+    },
+    "kvz": {
+      "name": "Tsakwambo"
+    },
+    "kwa": {
+      "name": "Dâw"
+    },
+    "kwb": {
+      "name": "Kwa"
+    },
+    "kwc": {
+      "name": "Likwala"
+    },
+    "kwd": {
+      "name": "Kwaio"
+    },
+    "kwe": {
+      "name": "Kwerba"
+    },
+    "kwf": {
+      "name": "Kwara'ae"
+    },
+    "kwg": {
+      "name": "Sara Kaba Deme"
+    },
+    "kwh": {
+      "name": "Kowiai"
+    },
+    "kwi": {
+      "name": "Awa-Cuaiquer"
+    },
+    "kwj": {
+      "name": "Kwanga"
+    },
+    "kwk": {
+      "name": "Kwakiutl"
+    },
+    "kwl": {
+      "name": "Kofyar"
+    },
+    "kwm": {
+      "name": "Kwambi"
+    },
+    "kwn": {
+      "name": "Kwangali"
+    },
+    "kwo": {
+      "name": "Kwomtari"
+    },
+    "kwp": {
+      "name": "Kodia"
+    },
+    "kwq": {
+      "name": "Kwak"
+    },
+    "kwr": {
+      "name": "Kwer"
+    },
+    "kws": {
+      "name": "Kwese"
+    },
+    "kwt": {
+      "name": "Kwesten"
+    },
+    "kwu": {
+      "name": "Kwakum"
+    },
+    "kwv": {
+      "name": "Sara Kaba Náà"
+    },
+    "kww": {
+      "name": "Kwinti"
+    },
+    "kwx": {
+      "name": "Khirwar"
+    },
+    "kwy": {
+      "name": "San Salvador Kongo"
+    },
+    "kwz": {
+      "name": "Kwadi"
+    },
+    "kxa": {
+      "name": "Kairiru"
+    },
+    "kxb": {
+      "name": "Krobu"
+    },
+    "kxc": {
+      "name": "Konso"
+    },
+    "kxd": {
+      "name": "Brunei"
+    },
+    "kxe": {
+      "name": "Kakihum"
+    },
+    "kxf": {
+      "name": "Manumanaw Karen"
+    },
+    "kxh": {
+      "name": "Karo (Ethiopia)"
+    },
+    "kxi": {
+      "name": "Keningau Murut"
+    },
+    "kxj": {
+      "name": "Kulfa"
+    },
+    "kxk": {
+      "name": "Zayein Karen"
+    },
+    "kxl": {
+      "name": "Nepali Kurux"
+    },
+    "kxm": {
+      "name": "Northern Khmer"
+    },
+    "kxn": {
+      "name": "Kanowit-Tanjong Melanau"
+    },
+    "kxo": {
+      "name": "Kanoé"
+    },
+    "kxp": {
+      "name": "Wadiyara Koli"
+    },
+    "kxq": {
+      "name": "Smärky Kanum"
+    },
+    "kxr": {
+      "name": "Koro (Papua New Guinea)"
+    },
+    "kxs": {
+      "name": "Kangjia"
+    },
+    "kxt": {
+      "name": "Koiwat"
+    },
+    "kxu": {
+      "name": "Kui (India)"
+    },
+    "kxv": {
+      "name": "Kuvi"
+    },
+    "kxw": {
+      "name": "Konai"
+    },
+    "kxx": {
+      "name": "Likuba"
+    },
+    "kxy": {
+      "name": "Kayong"
+    },
+    "kxz": {
+      "name": "Kerewo"
+    },
+    "kya": {
+      "name": "Kwaya"
+    },
+    "kyb": {
+      "name": "Butbut Kalinga"
+    },
+    "kyc": {
+      "name": "Kyaka"
+    },
+    "kyd": {
+      "name": "Karey"
+    },
+    "kye": {
+      "name": "Krache"
+    },
+    "kyf": {
+      "name": "Kouya"
+    },
+    "kyg": {
+      "name": "Keyagana"
+    },
+    "kyh": {
+      "name": "Karok"
+    },
+    "kyi": {
+      "name": "Kiput"
+    },
+    "kyj": {
+      "name": "Karao"
+    },
+    "kyk": {
+      "name": "Kamayo"
+    },
+    "kyl": {
+      "name": "Kalapuya"
+    },
+    "kym": {
+      "name": "Kpatili"
+    },
+    "kyn": {
+      "name": "Northern Binukidnon"
+    },
+    "kyo": {
+      "name": "Kelon"
+    },
+    "kyp": {
+      "name": "Kang"
+    },
+    "kyq": {
+      "name": "Kenga"
+    },
+    "kyr": {
+      "name": "Kuruáya"
+    },
+    "kys": {
+      "name": "Baram Kayan"
+    },
+    "kyt": {
+      "name": "Kayagar"
+    },
+    "kyu": {
+      "name": "Western Kayah"
+    },
+    "kyv": {
+      "name": "Kayort"
+    },
+    "kyw": {
+      "name": "Kudmali"
+    },
+    "kyx": {
+      "name": "Rapoisi"
+    },
+    "kyy": {
+      "name": "Kambaira"
+    },
+    "kyz": {
+      "name": "Kayabí"
+    },
+    "kza": {
+      "name": "Western Karaboro"
+    },
+    "kzb": {
+      "name": "Kaibobo"
+    },
+    "kzc": {
+      "name": "Bondoukou Kulango"
+    },
+    "kzd": {
+      "name": "Kadai"
+    },
+    "kze": {
+      "name": "Kosena"
+    },
+    "kzf": {
+      "name": "Da'a Kaili"
+    },
+    "kzg": {
+      "name": "Kikai"
+    },
+    "kzh": {
+      "name": "Kenuzi-Dongola"
+    },
+    "kzi": {
+      "name": "Kelabit"
+    },
+    "kzj": {
+      "name": "Coastal Kadazan"
+    },
+    "kzk": {
+      "name": "Kazukuru"
+    },
+    "kzl": {
+      "name": "Kayeli"
+    },
+    "kzm": {
+      "name": "Kais"
+    },
+    "kzn": {
+      "name": "Kokola"
+    },
+    "kzo": {
+      "name": "Kaningi"
+    },
+    "kzp": {
+      "name": "Kaidipang"
+    },
+    "kzq": {
+      "name": "Kaike"
+    },
+    "kzr": {
+      "name": "Karang"
+    },
+    "kzs": {
+      "name": "Sugut Dusun"
+    },
+    "kzt": {
+      "name": "Tambunan Dusun"
+    },
+    "kzu": {
+      "name": "Kayupulau"
+    },
+    "kzv": {
+      "name": "Komyandaret"
+    },
+    "kzw": {
+      "name": "Karirí-Xocó"
+    },
+    "kzx": {
+      "name": "Kamarian"
+    },
+    "kzy": {
+      "name": "Kango (Tshopo District)"
+    },
+    "kzz": {
+      "name": "Kalabra"
+    },
+    "laa": {
+      "name": "Southern Subanen"
+    },
+    "lab": {
+      "name": "Linear A"
+    },
+    "lac": {
+      "name": "Lacandon"
+    },
+    "lad": {
+      "name": "Ladino"
+    },
+    "lae": {
+      "name": "Pattani"
+    },
+    "laf": {
+      "name": "Lafofa"
+    },
+    "lag": {
+      "name": "Langi"
+    },
+    "lah": {
+      "name": "Lahnda"
+    },
+    "lai": {
+      "name": "Lambya"
+    },
+    "laj": {
+      "name": "Lango (Uganda)"
+    },
+    "lak": {
+      "name": "Laka (Nigeria)"
+    },
+    "lal": {
+      "name": "Lalia"
+    },
+    "lam": {
+      "name": "Lamba"
+    },
+    "lan": {
+      "name": "Laru"
+    },
+    "lap": {
+      "name": "Laka (Chad)"
+    },
+    "laq": {
+      "name": "Qabiao"
+    },
+    "lar": {
+      "name": "Larteh"
+    },
+    "las": {
+      "name": "Lama (Togo)"
+    },
+    "lau": {
+      "name": "Laba"
+    },
+    "law": {
+      "name": "Lauje"
+    },
+    "lax": {
+      "name": "Tiwa"
+    },
+    "lay": {
+      "name": "Lama Bai"
+    },
+    "laz": {
+      "name": "Aribwatsa"
+    },
+    "lba": {
+      "name": "Lui"
+    },
+    "lbb": {
+      "name": "Label"
+    },
+    "lbc": {
+      "name": "Lakkia"
+    },
+    "lbe": {
+      "name": "Lak"
+    },
+    "lbf": {
+      "name": "Tinani"
+    },
+    "lbg": {
+      "name": "Laopang"
+    },
+    "lbi": {
+      "name": "La'bi"
+    },
+    "lbj": {
+      "name": "Ladakhi"
+    },
+    "lbk": {
+      "name": "Central Bontok"
+    },
+    "lbl": {
+      "name": "Libon Bikol"
+    },
+    "lbm": {
+      "name": "Lodhi"
+    },
+    "lbn": {
+      "name": "Lamet"
+    },
+    "lbo": {
+      "name": "Laven"
+    },
+    "lbq": {
+      "name": "Wampar"
+    },
+    "lbr": {
+      "name": "Lohorung"
+    },
+    "lbs": {
+      "name": "Libyan Sign Language"
+    },
+    "lbt": {
+      "name": "Lachi"
+    },
+    "lbu": {
+      "name": "Labu"
+    },
+    "lbv": {
+      "name": "Lavatbura-Lamusong"
+    },
+    "lbw": {
+      "name": "Tolaki"
+    },
+    "lbx": {
+      "name": "Lawangan"
+    },
+    "lby": {
+      "name": "Lamu-Lamu"
+    },
+    "lbz": {
+      "name": "Lardil"
+    },
+    "lcc": {
+      "name": "Legenyem"
+    },
+    "lcd": {
+      "name": "Lola"
+    },
+    "lce": {
+      "name": "Loncong"
+    },
+    "lcf": {
+      "name": "Lubu"
+    },
+    "lch": {
+      "name": "Luchazi"
+    },
+    "lcl": {
+      "name": "Lisela"
+    },
+    "lcm": {
+      "name": "Tungag"
+    },
+    "lcp": {
+      "name": "Western Lawa"
+    },
+    "lcq": {
+      "name": "Luhu"
+    },
+    "lcs": {
+      "name": "Lisabata-Nuniali"
+    },
+    "lda": {
+      "name": "Kla-Dan"
+    },
+    "ldb": {
+      "name": "Dũya"
+    },
+    "ldd": {
+      "name": "Luri"
+    },
+    "ldg": {
+      "name": "Lenyima"
+    },
+    "ldh": {
+      "name": "Lamja-Dengsa-Tola"
+    },
+    "ldi": {
+      "name": "Laari"
+    },
+    "ldj": {
+      "name": "Lemoro"
+    },
+    "ldk": {
+      "name": "Leelau"
+    },
+    "ldl": {
+      "name": "Kaan"
+    },
+    "ldm": {
+      "name": "Landoma"
+    },
+    "ldn": {
+      "name": "Láadan"
+    },
+    "ldo": {
+      "name": "Loo"
+    },
+    "ldp": {
+      "name": "Tso"
+    },
+    "ldq": {
+      "name": "Lufu"
+    },
+    "lea": {
+      "name": "Lega-Shabunda"
+    },
+    "leb": {
+      "name": "Lala-Bisa"
+    },
+    "lec": {
+      "name": "Leco"
+    },
+    "led": {
+      "name": "Lendu"
+    },
+    "lee": {
+      "name": "Lyélé"
+    },
+    "lef": {
+      "name": "Lelemi"
+    },
+    "leg": {
+      "name": "Lengua"
+    },
+    "leh": {
+      "name": "Lenje"
+    },
+    "lei": {
+      "name": "Lemio"
+    },
+    "lej": {
+      "name": "Lengola"
+    },
+    "lek": {
+      "name": "Leipon"
+    },
+    "lel": {
+      "name": "Lele (Democratic Republic of Congo)"
+    },
+    "lem": {
+      "name": "Nomaande"
+    },
+    "len": {
+      "name": "Lenca"
+    },
+    "leo": {
+      "name": "Leti (Cameroon)"
+    },
+    "lep": {
+      "name": "Lepcha"
+    },
+    "leq": {
+      "name": "Lembena"
+    },
+    "ler": {
+      "name": "Lenkau"
+    },
+    "les": {
+      "name": "Lese"
+    },
+    "let": {
+      "name": "Lesing-Gelimi"
+    },
+    "leu": {
+      "name": "Kara (Papua New Guinea)"
+    },
+    "lev": {
+      "name": "Lamma"
+    },
+    "lew": {
+      "name": "Ledo Kaili"
+    },
+    "lex": {
+      "name": "Luang"
+    },
+    "ley": {
+      "name": "Lemolang"
+    },
+    "lez": {
+      "name": "Lezghian"
+    },
+    "lfa": {
+      "name": "Lefa"
+    },
+    "lfn": {
+      "name": "Lingua Franca Nova"
+    },
+    "lga": {
+      "name": "Lungga"
+    },
+    "lgb": {
+      "name": "Laghu"
+    },
+    "lgg": {
+      "name": "Lugbara"
+    },
+    "lgh": {
+      "name": "Laghuu"
+    },
+    "lgi": {
+      "name": "Lengilu"
+    },
+    "lgk": {
+      "name": "Lingarak"
+    },
+    "lgl": {
+      "name": "Wala"
+    },
+    "lgm": {
+      "name": "Lega-Mwenga"
+    },
+    "lgn": {
+      "name": "T'apo"
+    },
+    "lgq": {
+      "name": "Logba"
+    },
+    "lgr": {
+      "name": "Lengo"
+    },
+    "lgt": {
+      "name": "Pahi"
+    },
+    "lgu": {
+      "name": "Longgu"
+    },
+    "lgz": {
+      "name": "Ligenza"
+    },
+    "lha": {
+      "name": "Laha (Viet Nam)"
+    },
+    "lhh": {
+      "name": "Laha (Indonesia)"
+    },
+    "lhi": {
+      "name": "Lahu Shi"
+    },
+    "lhl": {
+      "name": "Lahul Lohar"
+    },
+    "lhm": {
+      "name": "Lhomi"
+    },
+    "lhn": {
+      "name": "Lahanan"
+    },
+    "lhp": {
+      "name": "Lhokpu"
+    },
+    "lhs": {
+      "name": "Mlahsö"
+    },
+    "lht": {
+      "name": "Lo-Toga"
+    },
+    "lhu": {
+      "name": "Lahu"
+    },
+    "lia": {
+      "name": "West-Central Limba"
+    },
+    "lib": {
+      "name": "Likum"
+    },
+    "lic": {
+      "name": "Hlai"
+    },
+    "lid": {
+      "name": "Nyindrou"
+    },
+    "lie": {
+      "name": "Likila"
+    },
+    "lif": {
+      "name": "Limbu"
+    },
+    "lig": {
+      "name": "Ligbi"
+    },
+    "lih": {
+      "name": "Lihir"
+    },
+    "lii": {
+      "name": "Lingkhim"
+    },
+    "lij": {
+      "name": "Ligurian"
+    },
+    "lik": {
+      "name": "Lika"
+    },
+    "lil": {
+      "name": "Lillooet"
+    },
+    "lio": {
+      "name": "Liki"
+    },
+    "lip": {
+      "name": "Sekpele"
+    },
+    "liq": {
+      "name": "Libido"
+    },
+    "lir": {
+      "name": "Liberian English"
+    },
+    "lis": {
+      "name": "Lisu"
+    },
+    "liu": {
+      "name": "Logorik"
+    },
+    "liv": {
+      "name": "Liv"
+    },
+    "liw": {
+      "name": "Col"
+    },
+    "lix": {
+      "name": "Liabuku"
+    },
+    "liy": {
+      "name": "Banda-Bambari"
+    },
+    "liz": {
+      "name": "Libinza"
+    },
+    "lja": {
+      "name": "Golpa"
+    },
+    "lje": {
+      "name": "Rampi"
+    },
+    "lji": {
+      "name": "Laiyolo"
+    },
+    "ljl": {
+      "name": "Li'o"
+    },
+    "ljp": {
+      "name": "Lampung Api"
+    },
+    "ljw": {
+      "name": "Yirandali"
+    },
+    "ljx": {
+      "name": "Yuru"
+    },
+    "lka": {
+      "name": "Lakalei"
+    },
+    "lkb": {
+      "name": "Kabras"
+    },
+    "lkc": {
+      "name": "Kucong"
+    },
+    "lkd": {
+      "name": "Lakondê"
+    },
+    "lke": {
+      "name": "Kenyi"
+    },
+    "lkh": {
+      "name": "Lakha"
+    },
+    "lki": {
+      "name": "Laki"
+    },
+    "lkj": {
+      "name": "Remun"
+    },
+    "lkl": {
+      "name": "Laeko-Libuat"
+    },
+    "lkm": {
+      "name": "Kalaamaya"
+    },
+    "lkn": {
+      "name": "Lakon"
+    },
+    "lko": {
+      "name": "Khayo"
+    },
+    "lkr": {
+      "name": "Päri"
+    },
+    "lks": {
+      "name": "Kisa"
+    },
+    "lkt": {
+      "name": "Lakota"
+    },
+    "lku": {
+      "name": "Kungkari"
+    },
+    "lky": {
+      "name": "Lokoya"
+    },
+    "lla": {
+      "name": "Lala-Roba"
+    },
+    "llb": {
+      "name": "Lolo"
+    },
+    "llc": {
+      "name": "Lele (Guinea)"
+    },
+    "lld": {
+      "name": "Ladin"
+    },
+    "lle": {
+      "name": "Lele (Papua New Guinea)"
+    },
+    "llf": {
+      "name": "Hermit"
+    },
+    "llg": {
+      "name": "Lole"
+    },
+    "llh": {
+      "name": "Lamu"
+    },
+    "lli": {
+      "name": "Teke-Laali"
+    },
+    "llj": {
+      "name": "Ladji Ladji"
+    },
+    "llk": {
+      "name": "Lelak"
+    },
+    "lll": {
+      "name": "Lilau"
+    },
+    "llm": {
+      "name": "Lasalimu"
+    },
+    "lln": {
+      "name": "Lele (Chad)"
+    },
+    "llo": {
+      "name": "Khlor"
+    },
+    "llp": {
+      "name": "North Efate"
+    },
+    "llq": {
+      "name": "Lolak"
+    },
+    "lls": {
+      "name": "Lithuanian Sign Language"
+    },
+    "llu": {
+      "name": "Lau"
+    },
+    "llx": {
+      "name": "Lauan"
+    },
+    "lma": {
+      "name": "East Limba"
+    },
+    "lmb": {
+      "name": "Merei"
+    },
+    "lmc": {
+      "name": "Limilngan"
+    },
+    "lmd": {
+      "name": "Lumun"
+    },
+    "lme": {
+      "name": "Pévé"
+    },
+    "lmf": {
+      "name": "South Lembata"
+    },
+    "lmg": {
+      "name": "Lamogai"
+    },
+    "lmh": {
+      "name": "Lambichhong"
+    },
+    "lmi": {
+      "name": "Lombi"
+    },
+    "lmj": {
+      "name": "West Lembata"
+    },
+    "lmk": {
+      "name": "Lamkang"
+    },
+    "lml": {
+      "name": "Hano"
+    },
+    "lmm": {
+      "name": "Lamam"
+    },
+    "lmn": {
+      "name": "Lambadi"
+    },
+    "lmo": {
+      "name": "Lombard"
+    },
+    "lmp": {
+      "name": "Limbum"
+    },
+    "lmq": {
+      "name": "Lamatuka"
+    },
+    "lmr": {
+      "name": "Lamalera"
+    },
+    "lmu": {
+      "name": "Lamenu"
+    },
+    "lmv": {
+      "name": "Lomaiviti"
+    },
+    "lmw": {
+      "name": "Lake Miwok"
+    },
+    "lmx": {
+      "name": "Laimbue"
+    },
+    "lmy": {
+      "name": "Lamboya"
+    },
+    "lmz": {
+      "name": "Lumbee"
+    },
+    "lna": {
+      "name": "Langbashe"
+    },
+    "lnb": {
+      "name": "Mbalanhu"
+    },
+    "lnd": {
+      "name": "Lundayeh"
+    },
+    "lng": {
+      "name": "Langobardic"
+    },
+    "lnh": {
+      "name": "Lanoh"
+    },
+    "lni": {
+      "name": "Daantanai'"
+    },
+    "lnj": {
+      "name": "Leningitij"
+    },
+    "lnl": {
+      "name": "South Central Banda"
+    },
+    "lnm": {
+      "name": "Langam"
+    },
+    "lnn": {
+      "name": "Lorediakarkar"
+    },
+    "lno": {
+      "name": "Lango (South Sudan)"
+    },
+    "lns": {
+      "name": "Lamnso'"
+    },
+    "lnu": {
+      "name": "Longuda"
+    },
+    "lnw": {
+      "name": "Lanima"
+    },
+    "lnz": {
+      "name": "Lonzo"
+    },
+    "loa": {
+      "name": "Loloda"
+    },
+    "lob": {
+      "name": "Lobi"
+    },
+    "loc": {
+      "name": "Inonhan"
+    },
+    "loe": {
+      "name": "Saluan"
+    },
+    "lof": {
+      "name": "Logol"
+    },
+    "log": {
+      "name": "Logo"
+    },
+    "loh": {
+      "name": "Narim"
+    },
+    "loi": {
+      "name": "Loma (Côte d'Ivoire)"
+    },
+    "loj": {
+      "name": "Lou"
+    },
+    "lok": {
+      "name": "Loko"
+    },
+    "lol": {
+      "name": "Mongo"
+    },
+    "lom": {
+      "name": "Loma (Liberia)"
+    },
+    "lon": {
+      "name": "Malawi Lomwe"
+    },
+    "loo": {
+      "name": "Lombo"
+    },
+    "lop": {
+      "name": "Lopa"
+    },
+    "loq": {
+      "name": "Lobala"
+    },
+    "lor": {
+      "name": "Téén"
+    },
+    "los": {
+      "name": "Loniu"
+    },
+    "lot": {
+      "name": "Otuho"
+    },
+    "lou": {
+      "name": "Louisiana Creole"
+    },
+    "lov": {
+      "name": "Lopi"
+    },
+    "low": {
+      "name": "Tampias Lobu"
+    },
+    "lox": {
+      "name": "Loun"
+    },
+    "loy": {
+      "name": "Loke"
+    },
+    "loz": {
+      "name": "Lozi"
+    },
+    "lpa": {
+      "name": "Lelepa"
+    },
+    "lpe": {
+      "name": "Lepki"
+    },
+    "lpn": {
+      "name": "Long Phuri Naga"
+    },
+    "lpo": {
+      "name": "Lipo"
+    },
+    "lpx": {
+      "name": "Lopit"
+    },
+    "lra": {
+      "name": "Rara Bakati'"
+    },
+    "lrc": {
+      "name": "Northern Luri"
+    },
+    "lre": {
+      "name": "Laurentian"
+    },
+    "lrg": {
+      "name": "Laragia"
+    },
+    "lri": {
+      "name": "Marachi"
+    },
+    "lrk": {
+      "name": "Loarki"
+    },
+    "lrl": {
+      "name": "Lari"
+    },
+    "lrm": {
+      "name": "Marama"
+    },
+    "lrn": {
+      "name": "Lorang"
+    },
+    "lro": {
+      "name": "Laro"
+    },
+    "lrr": {
+      "name": "Southern Yamphu"
+    },
+    "lrt": {
+      "name": "Larantuka Malay"
+    },
+    "lrv": {
+      "name": "Larevat"
+    },
+    "lrz": {
+      "name": "Lemerig"
+    },
+    "lsa": {
+      "name": "Lasgerdi"
+    },
+    "lsd": {
+      "name": "Lishana Deni"
+    },
+    "lse": {
+      "name": "Lusengo"
+    },
+    "lsg": {
+      "name": "Lyons Sign Language"
+    },
+    "lsh": {
+      "name": "Lish"
+    },
+    "lsi": {
+      "name": "Lashi"
+    },
+    "lsl": {
+      "name": "Latvian Sign Language"
+    },
+    "lsm": {
+      "name": "Saamia"
+    },
+    "lso": {
+      "name": "Laos Sign Language"
+    },
+    "lsp": {
+      "name": "Panamanian Sign Language"
+    },
+    "lsr": {
+      "name": "Aruop"
+    },
+    "lss": {
+      "name": "Lasi"
+    },
+    "lst": {
+      "name": "Trinidad and Tobago Sign Language"
+    },
+    "lsy": {
+      "name": "Mauritian Sign Language"
+    },
+    "ltc": {
+      "name": "Late Middle Chinese"
+    },
+    "ltg": {
+      "name": "Latgalian"
+    },
+    "lth": {
+      "name": "Thur"
+    },
+    "lti": {
+      "name": "Leti (Indonesia)"
+    },
+    "ltn": {
+      "name": "Latundê"
+    },
+    "lto": {
+      "name": "Tsotso"
+    },
+    "lts": {
+      "name": "Tachoni"
+    },
+    "ltu": {
+      "name": "Latu"
+    },
+    "lua": {
+      "name": "Luba-Lulua"
+    },
+    "luc": {
+      "name": "Aringa"
+    },
+    "lud": {
+      "name": "Ludian"
+    },
+    "lue": {
+      "name": "Luvale"
+    },
+    "luf": {
+      "name": "Laua"
+    },
+    "lui": {
+      "name": "Luiseno"
+    },
+    "luj": {
+      "name": "Luna"
+    },
+    "luk": {
+      "name": "Lunanakha"
+    },
+    "lul": {
+      "name": "Olu'bo"
+    },
+    "lum": {
+      "name": "Luimbi"
+    },
+    "lun": {
+      "name": "Lunda"
+    },
+    "luo": {
+      "name": "Luo (Kenya and Tanzania)"
+    },
+    "lup": {
+      "name": "Lumbu"
+    },
+    "luq": {
+      "name": "Lucumi"
+    },
+    "lur": {
+      "name": "Laura"
+    },
+    "lus": {
+      "name": "Lushai"
+    },
+    "lut": {
+      "name": "Lushootseed"
+    },
+    "luu": {
+      "name": "Lumba-Yakkha"
+    },
+    "luv": {
+      "name": "Luwati"
+    },
+    "luw": {
+      "name": "Luo (Cameroon)"
+    },
+    "luy": {
+      "name": "Luyia"
+    },
+    "luz": {
+      "name": "Southern Luri"
+    },
+    "lva": {
+      "name": "Maku'a"
+    },
+    "lvk": {
+      "name": "Lavukaleve"
+    },
+    "lvs": {
+      "name": "Standard Latvian"
+    },
+    "lvu": {
+      "name": "Levuka"
+    },
+    "lwa": {
+      "name": "Lwalu"
+    },
+    "lwe": {
+      "name": "Lewo Eleng"
+    },
+    "lwg": {
+      "name": "Wanga"
+    },
+    "lwh": {
+      "name": "White Lachi"
+    },
+    "lwl": {
+      "name": "Eastern Lawa"
+    },
+    "lwm": {
+      "name": "Laomian"
+    },
+    "lwo": {
+      "name": "Luwo"
+    },
+    "lws": {
+      "name": "Malawian Sign Language"
+    },
+    "lwt": {
+      "name": "Lewotobi"
+    },
+    "lwu": {
+      "name": "Lawu"
+    },
+    "lww": {
+      "name": "Lewo"
+    },
+    "lya": {
+      "name": "Layakha"
+    },
+    "lyg": {
+      "name": "Lyngngam"
+    },
+    "lyn": {
+      "name": "Luyana"
+    },
+    "lzh": {
+      "name": "Literary Chinese"
+    },
+    "lzl": {
+      "name": "Litzlitz"
+    },
+    "lzn": {
+      "name": "Leinong Naga"
+    },
+    "lzz": {
+      "name": "Laz"
+    },
+    "maa": {
+      "name": "San Jerónimo Tecóatl Mazatec"
+    },
+    "mab": {
+      "name": "Yutanduchi Mixtec"
+    },
+    "mad": {
+      "name": "Madurese"
+    },
+    "mae": {
+      "name": "Bo-Rukul"
+    },
+    "maf": {
+      "name": "Mafa"
+    },
+    "mag": {
+      "name": "Magahi"
+    },
+    "mai": {
+      "name": "Maithili"
+    },
+    "maj": {
+      "name": "Jalapa De Díaz Mazatec"
+    },
+    "mak": {
+      "name": "Makasar"
+    },
+    "mam": {
+      "name": "Mam"
+    },
+    "man": {
+      "name": "Mandingo"
+    },
+    "map": {
+      "name": "Austronesian languages"
+    },
+    "maq": {
+      "name": "Chiquihuitlán Mazatec"
+    },
+    "mas": {
+      "name": "Masai"
+    },
+    "mat": {
+      "name": "San Francisco Matlatzinca"
+    },
+    "mau": {
+      "name": "Huautla Mazatec"
+    },
+    "mav": {
+      "name": "Sateré-Mawé"
+    },
+    "maw": {
+      "name": "Mampruli"
+    },
+    "max": {
+      "name": "North Moluccan Malay"
+    },
+    "maz": {
+      "name": "Central Mazahua"
+    },
+    "mba": {
+      "name": "Higaonon"
+    },
+    "mbb": {
+      "name": "Western Bukidnon Manobo"
+    },
+    "mbc": {
+      "name": "Macushi"
+    },
+    "mbd": {
+      "name": "Dibabawon Manobo"
+    },
+    "mbe": {
+      "name": "Molale"
+    },
+    "mbf": {
+      "name": "Baba Malay"
+    },
+    "mbh": {
+      "name": "Mangseng"
+    },
+    "mbi": {
+      "name": "Ilianen Manobo"
+    },
+    "mbj": {
+      "name": "Nadëb"
+    },
+    "mbk": {
+      "name": "Malol"
+    },
+    "mbl": {
+      "name": "Maxakalí"
+    },
+    "mbm": {
+      "name": "Ombamba"
+    },
+    "mbn": {
+      "name": "Macaguán"
+    },
+    "mbo": {
+      "name": "Mbo (Cameroon)"
+    },
+    "mbp": {
+      "name": "Malayo"
+    },
+    "mbq": {
+      "name": "Maisin"
+    },
+    "mbr": {
+      "name": "Nukak Makú"
+    },
+    "mbs": {
+      "name": "Sarangani Manobo"
+    },
+    "mbt": {
+      "name": "Matigsalug Manobo"
+    },
+    "mbu": {
+      "name": "Mbula-Bwazza"
+    },
+    "mbv": {
+      "name": "Mbulungish"
+    },
+    "mbw": {
+      "name": "Maring"
+    },
+    "mbx": {
+      "name": "Mari (East Sepik Province)"
+    },
+    "mby": {
+      "name": "Memoni"
+    },
+    "mbz": {
+      "name": "Amoltepec Mixtec"
+    },
+    "mca": {
+      "name": "Maca"
+    },
+    "mcb": {
+      "name": "Machiguenga"
+    },
+    "mcc": {
+      "name": "Bitur"
+    },
+    "mcd": {
+      "name": "Sharanahua"
+    },
+    "mce": {
+      "name": "Itundujia Mixtec"
+    },
+    "mcf": {
+      "name": "Matsés"
+    },
+    "mcg": {
+      "name": "Mapoyo"
+    },
+    "mch": {
+      "name": "Maquiritari"
+    },
+    "mci": {
+      "name": "Mese"
+    },
+    "mcj": {
+      "name": "Mvanip"
+    },
+    "mck": {
+      "name": "Mbunda"
+    },
+    "mcl": {
+      "name": "Macaguaje"
+    },
+    "mcm": {
+      "name": "Malaccan Creole Portuguese"
+    },
+    "mcn": {
+      "name": "Masana"
+    },
+    "mco": {
+      "name": "Coatlán Mixe"
+    },
+    "mcp": {
+      "name": "Makaa"
+    },
+    "mcq": {
+      "name": "Ese"
+    },
+    "mcr": {
+      "name": "Menya"
+    },
+    "mcs": {
+      "name": "Mambai"
+    },
+    "mct": {
+      "name": "Mengisa"
+    },
+    "mcu": {
+      "name": "Cameroon Mambila"
+    },
+    "mcv": {
+      "name": "Minanibai"
+    },
+    "mcw": {
+      "name": "Mawa (Chad)"
+    },
+    "mcx": {
+      "name": "Mpiemo"
+    },
+    "mcy": {
+      "name": "South Watut"
+    },
+    "mcz": {
+      "name": "Mawan"
+    },
+    "mda": {
+      "name": "Mada (Nigeria)"
+    },
+    "mdb": {
+      "name": "Morigi"
+    },
+    "mdc": {
+      "name": "Male (Papua New Guinea)"
+    },
+    "mdd": {
+      "name": "Mbum"
+    },
+    "mde": {
+      "name": "Maba (Chad)"
+    },
+    "mdf": {
+      "name": "Moksha"
+    },
+    "mdg": {
+      "name": "Massalat"
+    },
+    "mdh": {
+      "name": "Maguindanaon"
+    },
+    "mdi": {
+      "name": "Mamvu"
+    },
+    "mdj": {
+      "name": "Mangbetu"
+    },
+    "mdk": {
+      "name": "Mangbutu"
+    },
+    "mdl": {
+      "name": "Maltese Sign Language"
+    },
+    "mdm": {
+      "name": "Mayogo"
+    },
+    "mdn": {
+      "name": "Mbati"
+    },
+    "mdp": {
+      "name": "Mbala"
+    },
+    "mdq": {
+      "name": "Mbole"
+    },
+    "mdr": {
+      "name": "Mandar"
+    },
+    "mds": {
+      "name": "Maria (Papua New Guinea)"
+    },
+    "mdt": {
+      "name": "Mbere"
+    },
+    "mdu": {
+      "name": "Mboko"
+    },
+    "mdv": {
+      "name": "Santa Lucía Monteverde Mixtec"
+    },
+    "mdw": {
+      "name": "Mbosi"
+    },
+    "mdx": {
+      "name": "Dizin"
+    },
+    "mdy": {
+      "name": "Male (Ethiopia)"
+    },
+    "mdz": {
+      "name": "Suruí Do Pará"
+    },
+    "mea": {
+      "name": "Menka"
+    },
+    "meb": {
+      "name": "Ikobi"
+    },
+    "mec": {
+      "name": "Mara"
+    },
+    "med": {
+      "name": "Melpa"
+    },
+    "mee": {
+      "name": "Mengen"
+    },
+    "mef": {
+      "name": "Megam"
+    },
+    "meg": {
+      "name": "Mea"
+    },
+    "meh": {
+      "name": "Southwestern Tlaxiaco Mixtec"
+    },
+    "mei": {
+      "name": "Midob"
+    },
+    "mej": {
+      "name": "Meyah"
+    },
+    "mek": {
+      "name": "Mekeo"
+    },
+    "mel": {
+      "name": "Central Melanau"
+    },
+    "mem": {
+      "name": "Mangala"
+    },
+    "men": {
+      "name": "Mende (Sierra Leone)"
+    },
+    "meo": {
+      "name": "Kedah Malay"
+    },
+    "mep": {
+      "name": "Miriwung"
+    },
+    "meq": {
+      "name": "Merey"
+    },
+    "mer": {
+      "name": "Meru"
+    },
+    "mes": {
+      "name": "Masmaje"
+    },
+    "met": {
+      "name": "Mato"
+    },
+    "meu": {
+      "name": "Motu"
+    },
+    "mev": {
+      "name": "Mano"
+    },
+    "mew": {
+      "name": "Maaka"
+    },
+    "mey": {
+      "name": "Hassaniyya"
+    },
+    "mez": {
+      "name": "Menominee"
+    },
+    "mfa": {
+      "name": "Pattani Malay"
+    },
+    "mfb": {
+      "name": "Bangka"
+    },
+    "mfc": {
+      "name": "Mba"
+    },
+    "mfd": {
+      "name": "Mendankwe-Nkwen"
+    },
+    "mfe": {
+      "name": "Morisyen"
+    },
+    "mff": {
+      "name": "Naki"
+    },
+    "mfg": {
+      "name": "Mogofin"
+    },
+    "mfh": {
+      "name": "Matal"
+    },
+    "mfi": {
+      "name": "Wandala"
+    },
+    "mfj": {
+      "name": "Mefele"
+    },
+    "mfk": {
+      "name": "North Mofu"
+    },
+    "mfl": {
+      "name": "Putai"
+    },
+    "mfm": {
+      "name": "Marghi South"
+    },
+    "mfn": {
+      "name": "Cross River Mbembe"
+    },
+    "mfo": {
+      "name": "Mbe"
+    },
+    "mfp": {
+      "name": "Makassar Malay"
+    },
+    "mfq": {
+      "name": "Moba"
+    },
+    "mfr": {
+      "name": "Marithiel"
+    },
+    "mfs": {
+      "name": "Mexican Sign Language"
+    },
+    "mft": {
+      "name": "Mokerang"
+    },
+    "mfu": {
+      "name": "Mbwela"
+    },
+    "mfv": {
+      "name": "Mandjak"
+    },
+    "mfw": {
+      "name": "Mulaha"
+    },
+    "mfx": {
+      "name": "Melo"
+    },
+    "mfy": {
+      "name": "Mayo"
+    },
+    "mfz": {
+      "name": "Mabaan"
+    },
+    "mga": {
+      "name": "Middle Irish (900-1200)"
+    },
+    "mgb": {
+      "name": "Mararit"
+    },
+    "mgc": {
+      "name": "Morokodo"
+    },
+    "mgd": {
+      "name": "Moru"
+    },
+    "mge": {
+      "name": "Mango"
+    },
+    "mgf": {
+      "name": "Maklew"
+    },
+    "mgg": {
+      "name": "Mpumpong"
+    },
+    "mgh": {
+      "name": "Makhuwa-Meetto"
+    },
+    "mgi": {
+      "name": "Lijili"
+    },
+    "mgj": {
+      "name": "Abureni"
+    },
+    "mgk": {
+      "name": "Mawes"
+    },
+    "mgl": {
+      "name": "Maleu-Kilenge"
+    },
+    "mgm": {
+      "name": "Mambae"
+    },
+    "mgn": {
+      "name": "Mbangi"
+    },
+    "mgo": {
+      "name": "Meta'"
+    },
+    "mgp": {
+      "name": "Eastern Magar"
+    },
+    "mgq": {
+      "name": "Malila"
+    },
+    "mgr": {
+      "name": "Mambwe-Lungu"
+    },
+    "mgs": {
+      "name": "Manda (Tanzania)"
+    },
+    "mgt": {
+      "name": "Mongol"
+    },
+    "mgu": {
+      "name": "Mailu"
+    },
+    "mgv": {
+      "name": "Matengo"
+    },
+    "mgw": {
+      "name": "Matumbi"
+    },
+    "mgx": {
+      "name": "Omati"
+    },
+    "mgy": {
+      "name": "Mbunga"
+    },
+    "mgz": {
+      "name": "Mbugwe"
+    },
+    "mha": {
+      "name": "Manda (India)"
+    },
+    "mhb": {
+      "name": "Mahongwe"
+    },
+    "mhc": {
+      "name": "Mocho"
+    },
+    "mhd": {
+      "name": "Mbugu"
+    },
+    "mhe": {
+      "name": "Besisi"
+    },
+    "mhf": {
+      "name": "Mamaa"
+    },
+    "mhg": {
+      "name": "Margu"
+    },
+    "mhh": {
+      "name": "Maskoy Pidgin"
+    },
+    "mhi": {
+      "name": "Ma'di"
+    },
+    "mhj": {
+      "name": "Mogholi"
+    },
+    "mhk": {
+      "name": "Mungaka"
+    },
+    "mhl": {
+      "name": "Mauwake"
+    },
+    "mhm": {
+      "name": "Makhuwa-Moniga"
+    },
+    "mhn": {
+      "name": "Mócheno"
+    },
+    "mho": {
+      "name": "Mashi (Zambia)"
+    },
+    "mhp": {
+      "name": "Balinese Malay"
+    },
+    "mhq": {
+      "name": "Mandan"
+    },
+    "mhr": {
+      "name": "Eastern Mari"
+    },
+    "mhs": {
+      "name": "Buru (Indonesia)"
+    },
+    "mht": {
+      "name": "Mandahuaca"
+    },
+    "mhu": {
+      "name": "Digaro-Mishmi"
+    },
+    "mhw": {
+      "name": "Mbukushu"
+    },
+    "mhx": {
+      "name": "Maru"
+    },
+    "mhy": {
+      "name": "Ma'anyan"
+    },
+    "mhz": {
+      "name": "Mor (Mor Islands)"
+    },
+    "mia": {
+      "name": "Miami"
+    },
+    "mib": {
+      "name": "Atatláhuca Mixtec"
+    },
+    "mic": {
+      "name": "Mi'kmaq"
+    },
+    "mid": {
+      "name": "Mandaic"
+    },
+    "mie": {
+      "name": "Ocotepec Mixtec"
+    },
+    "mif": {
+      "name": "Mofu-Gudur"
+    },
+    "mig": {
+      "name": "San Miguel El Grande Mixtec"
+    },
+    "mih": {
+      "name": "Chayuco Mixtec"
+    },
+    "mii": {
+      "name": "Chigmecatitlán Mixtec"
+    },
+    "mij": {
+      "name": "Abar"
+    },
+    "mik": {
+      "name": "Mikasuki"
+    },
+    "mil": {
+      "name": "Peñoles Mixtec"
+    },
+    "mim": {
+      "name": "Alacatlatzala Mixtec"
+    },
+    "min": {
+      "name": "Minangkabau"
+    },
+    "mio": {
+      "name": "Pinotepa Nacional Mixtec"
+    },
+    "mip": {
+      "name": "Apasco-Apoala Mixtec"
+    },
+    "miq": {
+      "name": "Mískito"
+    },
+    "mir": {
+      "name": "Isthmus Mixe"
+    },
+    "mis": {
+      "name": "Uncoded languages"
+    },
+    "mit": {
+      "name": "Southern Puebla Mixtec"
+    },
+    "miu": {
+      "name": "Cacaloxtepec Mixtec"
+    },
+    "miw": {
+      "name": "Akoye"
+    },
+    "mix": {
+      "name": "Mixtepec Mixtec"
+    },
+    "miy": {
+      "name": "Ayutla Mixtec"
+    },
+    "miz": {
+      "name": "Coatzospan Mixtec"
+    },
+    "mja": {
+      "name": "Mahei"
+    },
+    "mjb": {
+      "name": "Makalero"
+    },
+    "mjc": {
+      "name": "San Juan Colorado Mixtec"
+    },
+    "mjd": {
+      "name": "Northwest Maidu"
+    },
+    "mje": {
+      "name": "Muskum"
+    },
+    "mjg": {
+      "name": "Tu"
+    },
+    "mjh": {
+      "name": "Mwera (Nyasa)"
+    },
+    "mji": {
+      "name": "Kim Mun"
+    },
+    "mjj": {
+      "name": "Mawak"
+    },
+    "mjk": {
+      "name": "Matukar"
+    },
+    "mjl": {
+      "name": "Mandeali"
+    },
+    "mjm": {
+      "name": "Medebur"
+    },
+    "mjn": {
+      "name": "Ma (Papua New Guinea)"
+    },
+    "mjo": {
+      "name": "Malankuravan"
+    },
+    "mjp": {
+      "name": "Malapandaram"
+    },
+    "mjq": {
+      "name": "Malaryan"
+    },
+    "mjr": {
+      "name": "Malavedan"
+    },
+    "mjs": {
+      "name": "Miship"
+    },
+    "mjt": {
+      "name": "Sauria Paharia"
+    },
+    "mju": {
+      "name": "Manna-Dora"
+    },
+    "mjv": {
+      "name": "Mannan"
+    },
+    "mjw": {
+      "name": "Karbi"
+    },
+    "mjx": {
+      "name": "Mahali"
+    },
+    "mjy": {
+      "name": "Mahican"
+    },
+    "mjz": {
+      "name": "Majhi"
+    },
+    "mka": {
+      "name": "Mbre"
+    },
+    "mkb": {
+      "name": "Mal Paharia"
+    },
+    "mkc": {
+      "name": "Siliput"
+    },
+    "mke": {
+      "name": "Mawchi"
+    },
+    "mkf": {
+      "name": "Miya"
+    },
+    "mkg": {
+      "name": "Mak (China)"
+    },
+    "mkh": {
+      "name": "Mon-Khmer languages"
+    },
+    "mki": {
+      "name": "Dhatki"
+    },
+    "mkj": {
+      "name": "Mokilese"
+    },
+    "mkk": {
+      "name": "Byep"
+    },
+    "mkl": {
+      "name": "Mokole"
+    },
+    "mkm": {
+      "name": "Moklen"
+    },
+    "mkn": {
+      "name": "Kupang Malay"
+    },
+    "mko": {
+      "name": "Mingang Doso"
+    },
+    "mkp": {
+      "name": "Moikodi"
+    },
+    "mkq": {
+      "name": "Bay Miwok"
+    },
+    "mkr": {
+      "name": "Malas"
+    },
+    "mks": {
+      "name": "Silacayoapan Mixtec"
+    },
+    "mkt": {
+      "name": "Vamale"
+    },
+    "mku": {
+      "name": "Konyanka Maninka"
+    },
+    "mkv": {
+      "name": "Mafea"
+    },
+    "mkw": {
+      "name": "Kituba (Congo)"
+    },
+    "mkx": {
+      "name": "Kinamiging Manobo"
+    },
+    "mky": {
+      "name": "East Makian"
+    },
+    "mkz": {
+      "name": "Makasae"
+    },
+    "mla": {
+      "name": "Malo"
+    },
+    "mlb": {
+      "name": "Mbule"
+    },
+    "mlc": {
+      "name": "Cao Lan"
+    },
+    "mld": {
+      "name": "Malakhel"
+    },
+    "mle": {
+      "name": "Manambu"
+    },
+    "mlf": {
+      "name": "Mal"
+    },
+    "mlh": {
+      "name": "Mape"
+    },
+    "mli": {
+      "name": "Malimpung"
+    },
+    "mlj": {
+      "name": "Miltu"
+    },
+    "mlk": {
+      "name": "Ilwana"
+    },
+    "mll": {
+      "name": "Malua Bay"
+    },
+    "mlm": {
+      "name": "Mulam"
+    },
+    "mln": {
+      "name": "Malango"
+    },
+    "mlo": {
+      "name": "Mlomp"
+    },
+    "mlp": {
+      "name": "Bargam"
+    },
+    "mlq": {
+      "name": "Western Maninkakan"
+    },
+    "mlr": {
+      "name": "Vame"
+    },
+    "mls": {
+      "name": "Masalit"
+    },
+    "mlu": {
+      "name": "To'abaita"
+    },
+    "mlv": {
+      "name": "Motlav"
+    },
+    "mlw": {
+      "name": "Moloko"
+    },
+    "mlx": {
+      "name": "Malfaxal"
+    },
+    "mlz": {
+      "name": "Malaynon"
+    },
+    "mma": {
+      "name": "Mama"
+    },
+    "mmb": {
+      "name": "Momina"
+    },
+    "mmc": {
+      "name": "Michoacán Mazahua"
+    },
+    "mmd": {
+      "name": "Maonan"
+    },
+    "mme": {
+      "name": "Mae"
+    },
+    "mmf": {
+      "name": "Mundat"
+    },
+    "mmg": {
+      "name": "North Ambrym"
+    },
+    "mmh": {
+      "name": "Mehináku"
+    },
+    "mmi": {
+      "name": "Musar"
+    },
+    "mmj": {
+      "name": "Majhwar"
+    },
+    "mmk": {
+      "name": "Mukha-Dora"
+    },
+    "mml": {
+      "name": "Man Met"
+    },
+    "mmm": {
+      "name": "Maii"
+    },
+    "mmn": {
+      "name": "Mamanwa"
+    },
+    "mmo": {
+      "name": "Mangga Buang"
+    },
+    "mmp": {
+      "name": "Siawi"
+    },
+    "mmq": {
+      "name": "Musak"
+    },
+    "mmr": {
+      "name": "Western Xiangxi Miao"
+    },
+    "mmt": {
+      "name": "Malalamai"
+    },
+    "mmu": {
+      "name": "Mmaala"
+    },
+    "mmv": {
+      "name": "Miriti"
+    },
+    "mmw": {
+      "name": "Emae"
+    },
+    "mmx": {
+      "name": "Madak"
+    },
+    "mmy": {
+      "name": "Migaama"
+    },
+    "mmz": {
+      "name": "Mabaale"
+    },
+    "mna": {
+      "name": "Mbula"
+    },
+    "mnb": {
+      "name": "Muna"
+    },
+    "mnc": {
+      "name": "Manchu"
+    },
+    "mnd": {
+      "name": "Mondé"
+    },
+    "mne": {
+      "name": "Naba"
+    },
+    "mnf": {
+      "name": "Mundani"
+    },
+    "mng": {
+      "name": "Eastern Mnong"
+    },
+    "mnh": {
+      "name": "Mono (Democratic Republic of Congo)"
+    },
+    "mni": {
+      "name": "Manipuri"
+    },
+    "mnj": {
+      "name": "Munji"
+    },
+    "mnk": {
+      "name": "Mandinka"
+    },
+    "mnl": {
+      "name": "Tiale"
+    },
+    "mnm": {
+      "name": "Mapena"
+    },
+    "mnn": {
+      "name": "Southern Mnong"
+    },
+    "mno": {
+      "name": "Manobo languages"
+    },
+    "mnp": {
+      "name": "Min Bei Chinese"
+    },
+    "mnq": {
+      "name": "Minriq"
+    },
+    "mnr": {
+      "name": "Mono (USA)"
+    },
+    "mns": {
+      "name": "Mansi"
+    },
+    "mnt": {
+      "name": "Maykulan"
+    },
+    "mnu": {
+      "name": "Mer"
+    },
+    "mnv": {
+      "name": "Rennell-Bellona"
+    },
+    "mnw": {
+      "name": "Mon"
+    },
+    "mnx": {
+      "name": "Manikion"
+    },
+    "mny": {
+      "name": "Manyawa"
+    },
+    "mnz": {
+      "name": "Moni"
+    },
+    "moa": {
+      "name": "Mwan"
+    },
+    "moc": {
+      "name": "Mocoví"
+    },
+    "mod": {
+      "name": "Mobilian"
+    },
+    "moe": {
+      "name": "Montagnais"
+    },
+    "mof": {
+      "name": "Mohegan-Montauk-Narragansett"
+    },
+    "mog": {
+      "name": "Mongondow"
+    },
+    "moh": {
+      "name": "Mohawk"
+    },
+    "moi": {
+      "name": "Mboi"
+    },
+    "moj": {
+      "name": "Monzombo"
+    },
+    "mok": {
+      "name": "Morori"
+    },
+    "mom": {
+      "name": "Mangue"
+    },
+    "moo": {
+      "name": "Monom"
+    },
+    "mop": {
+      "name": "Mopán Maya"
+    },
+    "moq": {
+      "name": "Mor (Bomberai Peninsula)"
+    },
+    "mor": {
+      "name": "Moro"
+    },
+    "mos": {
+      "name": "Mossi"
+    },
+    "mot": {
+      "name": "Barí"
+    },
+    "mou": {
+      "name": "Mogum"
+    },
+    "mov": {
+      "name": "Mohave"
+    },
+    "mow": {
+      "name": "Moi (Congo)"
+    },
+    "mox": {
+      "name": "Molima"
+    },
+    "moy": {
+      "name": "Shekkacho"
+    },
+    "moz": {
+      "name": "Mukulu"
+    },
+    "mpa": {
+      "name": "Mpoto"
+    },
+    "mpb": {
+      "name": "Mullukmulluk"
+    },
+    "mpc": {
+      "name": "Mangarayi"
+    },
+    "mpd": {
+      "name": "Machinere"
+    },
+    "mpe": {
+      "name": "Majang"
+    },
+    "mpg": {
+      "name": "Marba"
+    },
+    "mph": {
+      "name": "Maung"
+    },
+    "mpi": {
+      "name": "Mpade"
+    },
+    "mpj": {
+      "name": "Martu Wangka"
+    },
+    "mpk": {
+      "name": "Mbara (Chad)"
+    },
+    "mpl": {
+      "name": "Middle Watut"
+    },
+    "mpm": {
+      "name": "Yosondúa Mixtec"
+    },
+    "mpn": {
+      "name": "Mindiri"
+    },
+    "mpo": {
+      "name": "Miu"
+    },
+    "mpp": {
+      "name": "Migabac"
+    },
+    "mpq": {
+      "name": "Matís"
+    },
+    "mpr": {
+      "name": "Vangunu"
+    },
+    "mps": {
+      "name": "Dadibi"
+    },
+    "mpt": {
+      "name": "Mian"
+    },
+    "mpu": {
+      "name": "Makuráp"
+    },
+    "mpv": {
+      "name": "Mungkip"
+    },
+    "mpw": {
+      "name": "Mapidian"
+    },
+    "mpx": {
+      "name": "Misima-Panaeati"
+    },
+    "mpy": {
+      "name": "Mapia"
+    },
+    "mpz": {
+      "name": "Mpi"
+    },
+    "mqa": {
+      "name": "Maba (Indonesia)"
+    },
+    "mqb": {
+      "name": "Mbuko"
+    },
+    "mqc": {
+      "name": "Mangole"
+    },
+    "mqe": {
+      "name": "Matepi"
+    },
+    "mqf": {
+      "name": "Momuna"
+    },
+    "mqg": {
+      "name": "Kota Bangun Kutai Malay"
+    },
+    "mqh": {
+      "name": "Tlazoyaltepec Mixtec"
+    },
+    "mqi": {
+      "name": "Mariri"
+    },
+    "mqj": {
+      "name": "Mamasa"
+    },
+    "mqk": {
+      "name": "Rajah Kabunsuwan Manobo"
+    },
+    "mql": {
+      "name": "Mbelime"
+    },
+    "mqm": {
+      "name": "South Marquesan"
+    },
+    "mqn": {
+      "name": "Moronene"
+    },
+    "mqo": {
+      "name": "Modole"
+    },
+    "mqp": {
+      "name": "Manipa"
+    },
+    "mqq": {
+      "name": "Minokok"
+    },
+    "mqr": {
+      "name": "Mander"
+    },
+    "mqs": {
+      "name": "West Makian"
+    },
+    "mqt": {
+      "name": "Mok"
+    },
+    "mqu": {
+      "name": "Mandari"
+    },
+    "mqv": {
+      "name": "Mosimo"
+    },
+    "mqw": {
+      "name": "Murupi"
+    },
+    "mqx": {
+      "name": "Mamuju"
+    },
+    "mqy": {
+      "name": "Manggarai"
+    },
+    "mqz": {
+      "name": "Pano"
+    },
+    "mra": {
+      "name": "Mlabri"
+    },
+    "mrb": {
+      "name": "Marino"
+    },
+    "mrc": {
+      "name": "Maricopa"
+    },
+    "mrd": {
+      "name": "Western Magar"
+    },
+    "mre": {
+      "name": "Martha's Vineyard Sign Language"
+    },
+    "mrf": {
+      "name": "Elseng"
+    },
+    "mrg": {
+      "name": "Mising"
+    },
+    "mrh": {
+      "name": "Mara Chin"
+    },
+    "mrj": {
+      "name": "Western Mari"
+    },
+    "mrk": {
+      "name": "Hmwaveke"
+    },
+    "mrl": {
+      "name": "Mortlockese"
+    },
+    "mrm": {
+      "name": "Merlav"
+    },
+    "mrn": {
+      "name": "Cheke Holo"
+    },
+    "mro": {
+      "name": "Mru"
+    },
+    "mrp": {
+      "name": "Morouas"
+    },
+    "mrq": {
+      "name": "North Marquesan"
+    },
+    "mrr": {
+      "name": "Maria (India)"
+    },
+    "mrs": {
+      "name": "Maragus"
+    },
+    "mrt": {
+      "name": "Marghi Central"
+    },
+    "mru": {
+      "name": "Mono (Cameroon)"
+    },
+    "mrv": {
+      "name": "Mangareva"
+    },
+    "mrw": {
+      "name": "Maranao"
+    },
+    "mrx": {
+      "name": "Maremgi"
+    },
+    "mry": {
+      "name": "Mandaya"
+    },
+    "mrz": {
+      "name": "Marind"
+    },
+    "msb": {
+      "name": "Masbatenyo"
+    },
+    "msc": {
+      "name": "Sankaran Maninka"
+    },
+    "msd": {
+      "name": "Yucatec Maya Sign Language"
+    },
+    "mse": {
+      "name": "Musey"
+    },
+    "msf": {
+      "name": "Mekwei"
+    },
+    "msg": {
+      "name": "Moraid"
+    },
+    "msh": {
+      "name": "Masikoro Malagasy"
+    },
+    "msi": {
+      "name": "Sabah Malay"
+    },
+    "msj": {
+      "name": "Ma (Democratic Republic of Congo)"
+    },
+    "msk": {
+      "name": "Mansaka"
+    },
+    "msl": {
+      "name": "Molof"
+    },
+    "msm": {
+      "name": "Agusan Manobo"
+    },
+    "msn": {
+      "name": "Vurës"
+    },
+    "mso": {
+      "name": "Mombum"
+    },
+    "msp": {
+      "name": "Maritsauá"
+    },
+    "msq": {
+      "name": "Caac"
+    },
+    "msr": {
+      "name": "Mongolian Sign Language"
+    },
+    "mss": {
+      "name": "West Masela"
+    },
+    "mst": {
+      "name": "Cataelano Mandaya"
+    },
+    "msu": {
+      "name": "Musom"
+    },
+    "msv": {
+      "name": "Maslam"
+    },
+    "msw": {
+      "name": "Mansoanka"
+    },
+    "msx": {
+      "name": "Moresada"
+    },
+    "msy": {
+      "name": "Aruamu"
+    },
+    "msz": {
+      "name": "Momare"
+    },
+    "mta": {
+      "name": "Cotabato Manobo"
+    },
+    "mtb": {
+      "name": "Anyin Morofo"
+    },
+    "mtc": {
+      "name": "Munit"
+    },
+    "mtd": {
+      "name": "Mualang"
+    },
+    "mte": {
+      "name": "Mono (Solomon Islands)"
+    },
+    "mtf": {
+      "name": "Murik (Papua New Guinea)"
+    },
+    "mtg": {
+      "name": "Una"
+    },
+    "mth": {
+      "name": "Munggui"
+    },
+    "mti": {
+      "name": "Maiwa (Papua New Guinea)"
+    },
+    "mtj": {
+      "name": "Moskona"
+    },
+    "mtk": {
+      "name": "Mbe'"
+    },
+    "mtl": {
+      "name": "Montol"
+    },
+    "mtm": {
+      "name": "Mator"
+    },
+    "mtn": {
+      "name": "Matagalpa"
+    },
+    "mto": {
+      "name": "Totontepec Mixe"
+    },
+    "mtp": {
+      "name": "Wichí Lhamtés Nocten"
+    },
+    "mtq": {
+      "name": "Muong"
+    },
+    "mtr": {
+      "name": "Mewari"
+    },
+    "mts": {
+      "name": "Yora"
+    },
+    "mtt": {
+      "name": "Mota"
+    },
+    "mtu": {
+      "name": "Tututepec Mixtec"
+    },
+    "mtv": {
+      "name": "Asaro'o"
+    },
+    "mtw": {
+      "name": "Southern Binukidnon"
+    },
+    "mtx": {
+      "name": "Tidaá Mixtec"
+    },
+    "mty": {
+      "name": "Nabi"
+    },
+    "mua": {
+      "name": "Mundang"
+    },
+    "mub": {
+      "name": "Mubi"
+    },
+    "muc": {
+      "name": "Ajumbu"
+    },
+    "mud": {
+      "name": "Mednyj Aleut"
+    },
+    "mue": {
+      "name": "Media Lengua"
+    },
+    "mug": {
+      "name": "Musgu"
+    },
+    "muh": {
+      "name": "Mündü"
+    },
+    "mui": {
+      "name": "Musi"
+    },
+    "muj": {
+      "name": "Mabire"
+    },
+    "muk": {
+      "name": "Mugom"
+    },
+    "mul": {
+      "name": "Multiple languages"
+    },
+    "mum": {
+      "name": "Maiwala"
+    },
+    "mun": {
+      "name": "Munda languages"
+    },
+    "muo": {
+      "name": "Nyong"
+    },
+    "mup": {
+      "name": "Malvi"
+    },
+    "muq": {
+      "name": "Eastern Xiangxi Miao"
+    },
+    "mur": {
+      "name": "Murle"
+    },
+    "mus": {
+      "name": "Creek"
+    },
+    "mut": {
+      "name": "Western Muria"
+    },
+    "muu": {
+      "name": "Yaaku"
+    },
+    "muv": {
+      "name": "Muthuvan"
+    },
+    "mux": {
+      "name": "Bo-Ung"
+    },
+    "muy": {
+      "name": "Muyang"
+    },
+    "muz": {
+      "name": "Mursi"
+    },
+    "mva": {
+      "name": "Manam"
+    },
+    "mvb": {
+      "name": "Mattole"
+    },
+    "mvd": {
+      "name": "Mamboru"
+    },
+    "mve": {
+      "name": "Marwari (Pakistan)"
+    },
+    "mvf": {
+      "name": "Peripheral Mongolian"
+    },
+    "mvg": {
+      "name": "Yucuañe Mixtec"
+    },
+    "mvh": {
+      "name": "Mulgi"
+    },
+    "mvi": {
+      "name": "Miyako"
+    },
+    "mvk": {
+      "name": "Mekmek"
+    },
+    "mvl": {
+      "name": "Mbara (Australia)"
+    },
+    "mvm": {
+      "name": "Muya"
+    },
+    "mvn": {
+      "name": "Minaveha"
+    },
+    "mvo": {
+      "name": "Marovo"
+    },
+    "mvp": {
+      "name": "Duri"
+    },
+    "mvq": {
+      "name": "Moere"
+    },
+    "mvr": {
+      "name": "Marau"
+    },
+    "mvs": {
+      "name": "Massep"
+    },
+    "mvt": {
+      "name": "Mpotovoro"
+    },
+    "mvu": {
+      "name": "Marfa"
+    },
+    "mvv": {
+      "name": "Tagal Murut"
+    },
+    "mvw": {
+      "name": "Machinga"
+    },
+    "mvx": {
+      "name": "Meoswar"
+    },
+    "mvy": {
+      "name": "Indus Kohistani"
+    },
+    "mvz": {
+      "name": "Mesqan"
+    },
+    "mwa": {
+      "name": "Mwatebu"
+    },
+    "mwb": {
+      "name": "Juwal"
+    },
+    "mwc": {
+      "name": "Are"
+    },
+    "mwd": {
+      "name": "Mudbura"
+    },
+    "mwe": {
+      "name": "Mwera (Chimwera)"
+    },
+    "mwf": {
+      "name": "Murrinh-Patha"
+    },
+    "mwg": {
+      "name": "Aiklep"
+    },
+    "mwh": {
+      "name": "Mouk-Aria"
+    },
+    "mwi": {
+      "name": "Labo"
+    },
+    "mwj": {
+      "name": "Maligo"
+    },
+    "mwk": {
+      "name": "Kita Maninkakan"
+    },
+    "mwl": {
+      "name": "Mirandese"
+    },
+    "mwm": {
+      "name": "Sar"
+    },
+    "mwn": {
+      "name": "Nyamwanga"
+    },
+    "mwo": {
+      "name": "Central Maewo"
+    },
+    "mwp": {
+      "name": "Kala Lagaw Ya"
+    },
+    "mwq": {
+      "name": "Mün Chin"
+    },
+    "mwr": {
+      "name": "Marwari"
+    },
+    "mws": {
+      "name": "Mwimbi-Muthambi"
+    },
+    "mwt": {
+      "name": "Moken"
+    },
+    "mwu": {
+      "name": "Mittu"
+    },
+    "mwv": {
+      "name": "Mentawai"
+    },
+    "mww": {
+      "name": "Hmong Daw"
+    },
+    "mwx": {
+      "name": "Mediak"
+    },
+    "mwy": {
+      "name": "Mosiro"
+    },
+    "mwz": {
+      "name": "Moingi"
+    },
+    "mxa": {
+      "name": "Northwest Oaxaca Mixtec"
+    },
+    "mxb": {
+      "name": "Tezoatlán Mixtec"
+    },
+    "mxc": {
+      "name": "Manyika"
+    },
+    "mxd": {
+      "name": "Modang"
+    },
+    "mxe": {
+      "name": "Mele-Fila"
+    },
+    "mxf": {
+      "name": "Malgbe"
+    },
+    "mxg": {
+      "name": "Mbangala"
+    },
+    "mxh": {
+      "name": "Mvuba"
+    },
+    "mxi": {
+      "name": "Mozarabic"
+    },
+    "mxj": {
+      "name": "Miju-Mishmi"
+    },
+    "mxk": {
+      "name": "Monumbo"
+    },
+    "mxl": {
+      "name": "Maxi Gbe"
+    },
+    "mxm": {
+      "name": "Meramera"
+    },
+    "mxn": {
+      "name": "Moi (Indonesia)"
+    },
+    "mxo": {
+      "name": "Mbowe"
+    },
+    "mxp": {
+      "name": "Tlahuitoltepec Mixe"
+    },
+    "mxq": {
+      "name": "Juquila Mixe"
+    },
+    "mxr": {
+      "name": "Murik (Malaysia)"
+    },
+    "mxs": {
+      "name": "Huitepec Mixtec"
+    },
+    "mxt": {
+      "name": "Jamiltepec Mixtec"
+    },
+    "mxu": {
+      "name": "Mada (Cameroon)"
+    },
+    "mxv": {
+      "name": "Metlatónoc Mixtec"
+    },
+    "mxw": {
+      "name": "Namo"
+    },
+    "mxx": {
+      "name": "Mahou"
+    },
+    "mxy": {
+      "name": "Southeastern Nochixtlán Mixtec"
+    },
+    "mxz": {
+      "name": "Central Masela"
+    },
+    "myb": {
+      "name": "Mbay"
+    },
+    "myc": {
+      "name": "Mayeka"
+    },
+    "myd": {
+      "name": "Maramba"
+    },
+    "mye": {
+      "name": "Myene"
+    },
+    "myf": {
+      "name": "Bambassi"
+    },
+    "myg": {
+      "name": "Manta"
+    },
+    "myh": {
+      "name": "Makah"
+    },
+    "myi": {
+      "name": "Mina (India)"
+    },
+    "myj": {
+      "name": "Mangayat"
+    },
+    "myk": {
+      "name": "Mamara Senoufo"
+    },
+    "myl": {
+      "name": "Moma"
+    },
+    "mym": {
+      "name": "Me'en"
+    },
+    "myn": {
+      "name": "Mayan languages"
+    },
+    "myo": {
+      "name": "Anfillo"
+    },
+    "myp": {
+      "name": "Pirahã"
+    },
+    "myq": {
+      "name": "Forest Maninka"
+    },
+    "myr": {
+      "name": "Muniche"
+    },
+    "mys": {
+      "name": "Mesmes"
+    },
+    "myt": {
+      "name": "Sangab Mandaya"
+    },
+    "myu": {
+      "name": "Mundurukú"
+    },
+    "myv": {
+      "name": "Erzya"
+    },
+    "myw": {
+      "name": "Muyuw"
+    },
+    "myx": {
+      "name": "Masaaba"
+    },
+    "myy": {
+      "name": "Macuna"
+    },
+    "myz": {
+      "name": "Classical Mandaic"
+    },
+    "mza": {
+      "name": "Santa María Zacatepec Mixtec"
+    },
+    "mzb": {
+      "name": "Tumzabt"
+    },
+    "mzc": {
+      "name": "Madagascar Sign Language"
+    },
+    "mzd": {
+      "name": "Malimba"
+    },
+    "mze": {
+      "name": "Morawa"
+    },
+    "mzg": {
+      "name": "Monastic Sign Language"
+    },
+    "mzh": {
+      "name": "Wichí Lhamtés Güisnay"
+    },
+    "mzi": {
+      "name": "Ixcatlán Mazatec"
+    },
+    "mzj": {
+      "name": "Manya"
+    },
+    "mzk": {
+      "name": "Nigeria Mambila"
+    },
+    "mzl": {
+      "name": "Mazatlán Mixe"
+    },
+    "mzm": {
+      "name": "Mumuye"
+    },
+    "mzn": {
+      "name": "Mazanderani"
+    },
+    "mzo": {
+      "name": "Matipuhy"
+    },
+    "mzp": {
+      "name": "Movima"
+    },
+    "mzq": {
+      "name": "Mori Atas"
+    },
+    "mzr": {
+      "name": "Marúbo"
+    },
+    "mzs": {
+      "name": "Macanese"
+    },
+    "mzt": {
+      "name": "Mintil"
+    },
+    "mzu": {
+      "name": "Inapang"
+    },
+    "mzv": {
+      "name": "Manza"
+    },
+    "mzw": {
+      "name": "Deg"
+    },
+    "mzx": {
+      "name": "Mawayana"
+    },
+    "mzy": {
+      "name": "Mozambican Sign Language"
+    },
+    "mzz": {
+      "name": "Maiadomu"
+    },
+    "naa": {
+      "name": "Namla"
+    },
+    "nab": {
+      "name": "Southern Nambikuára"
+    },
+    "nac": {
+      "name": "Narak"
+    },
+    "nad": {
+      "name": "Nijadali"
+    },
+    "nae": {
+      "name": "Naka'ela"
+    },
+    "naf": {
+      "name": "Nabak"
+    },
+    "nag": {
+      "name": "Naga Pidgin"
+    },
+    "nah": {
+      "name": "Nahuatl languages"
+    },
+    "nai": {
+      "name": "North American Indian languages"
+    },
+    "naj": {
+      "name": "Nalu"
+    },
+    "nak": {
+      "name": "Nakanai"
+    },
+    "nal": {
+      "name": "Nalik"
+    },
+    "nam": {
+      "name": "Ngan'gityemerri"
+    },
+    "nan": {
+      "name": "Min Nan Chinese"
+    },
+    "nao": {
+      "name": "Naaba"
+    },
+    "nap": {
+      "name": "Neapolitan"
+    },
+    "naq": {
+      "name": "Khoekhoe"
+    },
+    "nar": {
+      "name": "Iguta"
+    },
+    "nas": {
+      "name": "Naasioi"
+    },
+    "nat": {
+      "name": "Ca̱hungwa̱rya̱"
+    },
+    "naw": {
+      "name": "Nawuri"
+    },
+    "nax": {
+      "name": "Nakwi"
+    },
+    "nay": {
+      "name": "Narrinyeri"
+    },
+    "naz": {
+      "name": "Coatepec Nahuatl"
+    },
+    "nba": {
+      "name": "Nyemba"
+    },
+    "nbb": {
+      "name": "Ndoe"
+    },
+    "nbc": {
+      "name": "Chang Naga"
+    },
+    "nbd": {
+      "name": "Ngbinda"
+    },
+    "nbe": {
+      "name": "Konyak Naga"
+    },
+    "nbf": {
+      "name": "Naxi"
+    },
+    "nbg": {
+      "name": "Nagarchal"
+    },
+    "nbh": {
+      "name": "Ngamo"
+    },
+    "nbi": {
+      "name": "Mao Naga"
+    },
+    "nbj": {
+      "name": "Ngarinman"
+    },
+    "nbk": {
+      "name": "Nake"
+    },
+    "nbm": {
+      "name": "Ngbaka Ma'bo"
+    },
+    "nbn": {
+      "name": "Kuri"
+    },
+    "nbo": {
+      "name": "Nkukoli"
+    },
+    "nbp": {
+      "name": "Nnam"
+    },
+    "nbq": {
+      "name": "Nggem"
+    },
+    "nbr": {
+      "name": "Numana-Nunku-Gbantu-Numbu"
+    },
+    "nbs": {
+      "name": "Namibian Sign Language"
+    },
+    "nbt": {
+      "name": "Na"
+    },
+    "nbu": {
+      "name": "Rongmei Naga"
+    },
+    "nbv": {
+      "name": "Ngamambo"
+    },
+    "nbw": {
+      "name": "Southern Ngbandi"
+    },
+    "nbx": {
+      "name": "Ngura"
+    },
+    "nby": {
+      "name": "Ningera"
+    },
+    "nca": {
+      "name": "Iyo"
+    },
+    "ncb": {
+      "name": "Central Nicobarese"
+    },
+    "ncc": {
+      "name": "Ponam"
+    },
+    "ncd": {
+      "name": "Nachering"
+    },
+    "nce": {
+      "name": "Yale"
+    },
+    "ncf": {
+      "name": "Notsi"
+    },
+    "ncg": {
+      "name": "Nisga'a"
+    },
+    "nch": {
+      "name": "Central Huasteca Nahuatl"
+    },
+    "nci": {
+      "name": "Classical Nahuatl"
+    },
+    "ncj": {
+      "name": "Northern Puebla Nahuatl"
+    },
+    "nck": {
+      "name": "Nakara"
+    },
+    "ncl": {
+      "name": "Michoacán Nahuatl"
+    },
+    "ncm": {
+      "name": "Nambo"
+    },
+    "ncn": {
+      "name": "Nauna"
+    },
+    "nco": {
+      "name": "Sibe"
+    },
+    "ncp": {
+      "name": "Ndaktup"
+    },
+    "ncq": {
+      "name": "Northern Katang"
+    },
+    "ncr": {
+      "name": "Ncane"
+    },
+    "ncs": {
+      "name": "Nicaraguan Sign Language"
+    },
+    "nct": {
+      "name": "Chothe Naga"
+    },
+    "ncu": {
+      "name": "Chumburung"
+    },
+    "ncx": {
+      "name": "Central Puebla Nahuatl"
+    },
+    "ncz": {
+      "name": "Natchez"
+    },
+    "nda": {
+      "name": "Ndasa"
+    },
+    "ndb": {
+      "name": "Kenswei Nsei"
+    },
+    "ndc": {
+      "name": "Ndau"
+    },
+    "ndd": {
+      "name": "Nde-Nsele-Nta"
+    },
+    "ndf": {
+      "name": "Nadruvian"
+    },
+    "ndg": {
+      "name": "Ndengereko"
+    },
+    "ndh": {
+      "name": "Ndali"
+    },
+    "ndi": {
+      "name": "Samba Leko"
+    },
+    "ndj": {
+      "name": "Ndamba"
+    },
+    "ndk": {
+      "name": "Ndaka"
+    },
+    "ndl": {
+      "name": "Ndolo"
+    },
+    "ndm": {
+      "name": "Ndam"
+    },
+    "ndn": {
+      "name": "Ngundi"
+    },
+    "ndp": {
+      "name": "Ndo"
+    },
+    "ndq": {
+      "name": "Ndombe"
+    },
+    "ndr": {
+      "name": "Ndoola"
+    },
+    "nds": {
+      "name": "Low German"
+    },
+    "ndt": {
+      "name": "Ndunga"
+    },
+    "ndu": {
+      "name": "Dugun"
+    },
+    "ndv": {
+      "name": "Ndut"
+    },
+    "ndw": {
+      "name": "Ndobo"
+    },
+    "ndx": {
+      "name": "Nduga"
+    },
+    "ndy": {
+      "name": "Lutos"
+    },
+    "ndz": {
+      "name": "Ndogo"
+    },
+    "nea": {
+      "name": "Eastern Ngad'a"
+    },
+    "neb": {
+      "name": "Toura (Côte d'Ivoire)"
+    },
+    "nec": {
+      "name": "Nedebang"
+    },
+    "ned": {
+      "name": "Nde-Gbite"
+    },
+    "nee": {
+      "name": "Nêlêmwa-Nixumwak"
+    },
+    "nef": {
+      "name": "Nefamese"
+    },
+    "neg": {
+      "name": "Negidal"
+    },
+    "neh": {
+      "name": "Nyenkha"
+    },
+    "nei": {
+      "name": "Neo-Hittite"
+    },
+    "nej": {
+      "name": "Neko"
+    },
+    "nek": {
+      "name": "Neku"
+    },
+    "nem": {
+      "name": "Nemi"
+    },
+    "nen": {
+      "name": "Nengone"
+    },
+    "neo": {
+      "name": "Ná-Meo"
+    },
+    "neq": {
+      "name": "North Central Mixe"
+    },
+    "ner": {
+      "name": "Yahadian"
+    },
+    "nes": {
+      "name": "Bhoti Kinnauri"
+    },
+    "net": {
+      "name": "Nete"
+    },
+    "neu": {
+      "name": "Neo"
+    },
+    "nev": {
+      "name": "Nyaheun"
+    },
+    "new": {
+      "name": "Newari"
+    },
+    "nex": {
+      "name": "Neme"
+    },
+    "ney": {
+      "name": "Neyo"
+    },
+    "nez": {
+      "name": "Nez Perce"
+    },
+    "nfa": {
+      "name": "Dhao"
+    },
+    "nfd": {
+      "name": "Ahwai"
+    },
+    "nfl": {
+      "name": "Ayiwo"
+    },
+    "nfr": {
+      "name": "Nafaanra"
+    },
+    "nfu": {
+      "name": "Mfumte"
+    },
+    "nga": {
+      "name": "Ngbaka"
+    },
+    "ngb": {
+      "name": "Northern Ngbandi"
+    },
+    "ngc": {
+      "name": "Ngombe (Democratic Republic of Congo)"
+    },
+    "ngd": {
+      "name": "Ngando (Central African Republic)"
+    },
+    "nge": {
+      "name": "Ngemba"
+    },
+    "ngf": {
+      "name": "Trans-New Guinea languages"
+    },
+    "ngg": {
+      "name": "Ngbaka Manza"
+    },
+    "ngh": {
+      "name": "N/u"
+    },
+    "ngi": {
+      "name": "Ngizim"
+    },
+    "ngj": {
+      "name": "Ngie"
+    },
+    "ngk": {
+      "name": "Dalabon"
+    },
+    "ngl": {
+      "name": "Lomwe"
+    },
+    "ngm": {
+      "name": "Ngatik Men's Creole"
+    },
+    "ngn": {
+      "name": "Ngwo"
+    },
+    "ngo": {
+      "name": "Ngoni"
+    },
+    "ngp": {
+      "name": "Ngulu"
+    },
+    "ngq": {
+      "name": "Ngurimi"
+    },
+    "ngr": {
+      "name": "Engdewu"
+    },
+    "ngs": {
+      "name": "Gvoko"
+    },
+    "ngt": {
+      "name": "Kriang"
+    },
+    "ngu": {
+      "name": "Guerrero Nahuatl"
+    },
+    "ngv": {
+      "name": "Nagumi"
+    },
+    "ngw": {
+      "name": "Ngwaba"
+    },
+    "ngx": {
+      "name": "Nggwahyi"
+    },
+    "ngy": {
+      "name": "Tibea"
+    },
+    "ngz": {
+      "name": "Ngungwel"
+    },
+    "nha": {
+      "name": "Nhanda"
+    },
+    "nhb": {
+      "name": "Beng"
+    },
+    "nhc": {
+      "name": "Tabasco Nahuatl"
+    },
+    "nhd": {
+      "name": "Chiripá"
+    },
+    "nhe": {
+      "name": "Eastern Huasteca Nahuatl"
+    },
+    "nhf": {
+      "name": "Nhuwala"
+    },
+    "nhg": {
+      "name": "Tetelcingo Nahuatl"
+    },
+    "nhh": {
+      "name": "Nahari"
+    },
+    "nhi": {
+      "name": "Zacatlán-Ahuacatlán-Tepetzintla Nahuatl"
+    },
+    "nhk": {
+      "name": "Isthmus-Cosoleacaque Nahuatl"
+    },
+    "nhm": {
+      "name": "Morelos Nahuatl"
+    },
+    "nhn": {
+      "name": "Central Nahuatl"
+    },
+    "nho": {
+      "name": "Takuu"
+    },
+    "nhp": {
+      "name": "Isthmus-Pajapan Nahuatl"
+    },
+    "nhq": {
+      "name": "Huaxcaleca Nahuatl"
+    },
+    "nhr": {
+      "name": "Naro"
+    },
+    "nht": {
+      "name": "Ometepec Nahuatl"
+    },
+    "nhu": {
+      "name": "Noone"
+    },
+    "nhv": {
+      "name": "Temascaltepec Nahuatl"
+    },
+    "nhw": {
+      "name": "Western Huasteca Nahuatl"
+    },
+    "nhx": {
+      "name": "Isthmus-Mecayapan Nahuatl"
+    },
+    "nhy": {
+      "name": "Northern Oaxaca Nahuatl"
+    },
+    "nhz": {
+      "name": "Santa María La Alta Nahuatl"
+    },
+    "nia": {
+      "name": "Nias"
+    },
+    "nib": {
+      "name": "Nakame"
+    },
+    "nic": {
+      "name": "Niger-Kordofanian languages"
+    },
+    "nid": {
+      "name": "Ngandi"
+    },
+    "nie": {
+      "name": "Niellim"
+    },
+    "nif": {
+      "name": "Nek"
+    },
+    "nig": {
+      "name": "Ngalakan"
+    },
+    "nih": {
+      "name": "Nyiha (Tanzania)"
+    },
+    "nii": {
+      "name": "Nii"
+    },
+    "nij": {
+      "name": "Ngaju"
+    },
+    "nik": {
+      "name": "Southern Nicobarese"
+    },
+    "nil": {
+      "name": "Nila"
+    },
+    "nim": {
+      "name": "Nilamba"
+    },
+    "nin": {
+      "name": "Ninzo"
+    },
+    "nio": {
+      "name": "Nganasan"
+    },
+    "niq": {
+      "name": "Nandi"
+    },
+    "nir": {
+      "name": "Nimboran"
+    },
+    "nis": {
+      "name": "Nimi"
+    },
+    "nit": {
+      "name": "Southeastern Kolami"
+    },
+    "niu": {
+      "name": "Niuean"
+    },
+    "niv": {
+      "name": "Gilyak"
+    },
+    "niw": {
+      "name": "Nimo"
+    },
+    "nix": {
+      "name": "Hema"
+    },
+    "niy": {
+      "name": "Ngiti"
+    },
+    "niz": {
+      "name": "Ningil"
+    },
+    "nja": {
+      "name": "Nzanyi"
+    },
+    "njb": {
+      "name": "Nocte Naga"
+    },
+    "njd": {
+      "name": "Ndonde Hamba"
+    },
+    "njh": {
+      "name": "Lotha Naga"
+    },
+    "nji": {
+      "name": "Gudanji"
+    },
+    "njj": {
+      "name": "Njen"
+    },
+    "njl": {
+      "name": "Njalgulgule"
+    },
+    "njm": {
+      "name": "Angami Naga"
+    },
+    "njn": {
+      "name": "Liangmai Naga"
+    },
+    "njo": {
+      "name": "Ao Naga"
+    },
+    "njr": {
+      "name": "Njerep"
+    },
+    "njs": {
+      "name": "Nisa"
+    },
+    "njt": {
+      "name": "Ndyuka-Trio Pidgin"
+    },
+    "nju": {
+      "name": "Ngadjunmaya"
+    },
+    "njx": {
+      "name": "Kunyi"
+    },
+    "njy": {
+      "name": "Njyem"
+    },
+    "njz": {
+      "name": "Nyishi"
+    },
+    "nka": {
+      "name": "Nkoya"
+    },
+    "nkb": {
+      "name": "Khoibu Naga"
+    },
+    "nkc": {
+      "name": "Nkongho"
+    },
+    "nkd": {
+      "name": "Koireng"
+    },
+    "nke": {
+      "name": "Duke"
+    },
+    "nkf": {
+      "name": "Inpui Naga"
+    },
+    "nkg": {
+      "name": "Nekgini"
+    },
+    "nkh": {
+      "name": "Khezha Naga"
+    },
+    "nki": {
+      "name": "Thangal Naga"
+    },
+    "nkj": {
+      "name": "Nakai"
+    },
+    "nkk": {
+      "name": "Nokuku"
+    },
+    "nkm": {
+      "name": "Namat"
+    },
+    "nkn": {
+      "name": "Nkangala"
+    },
+    "nko": {
+      "name": "Nkonya"
+    },
+    "nkp": {
+      "name": "Niuatoputapu"
+    },
+    "nkq": {
+      "name": "Nkami"
+    },
+    "nkr": {
+      "name": "Nukuoro"
+    },
+    "nks": {
+      "name": "North Asmat"
+    },
+    "nkt": {
+      "name": "Nyika (Tanzania)"
+    },
+    "nku": {
+      "name": "Bouna Kulango"
+    },
+    "nkv": {
+      "name": "Nyika (Malawi and Zambia)"
+    },
+    "nkw": {
+      "name": "Nkutu"
+    },
+    "nkx": {
+      "name": "Nkoroo"
+    },
+    "nkz": {
+      "name": "Nkari"
+    },
+    "nla": {
+      "name": "Ngombale"
+    },
+    "nlc": {
+      "name": "Nalca"
+    },
+    "nle": {
+      "name": "East Nyala"
+    },
+    "nlg": {
+      "name": "Gela"
+    },
+    "nli": {
+      "name": "Grangali"
+    },
+    "nlj": {
+      "name": "Nyali"
+    },
+    "nlk": {
+      "name": "Ninia Yali"
+    },
+    "nll": {
+      "name": "Nihali"
+    },
+    "nlm": {
+      "name": "Mankiyali"
+    },
+    "nln": {
+      "name": "Durango Nahuatl"
+    },
+    "nlo": {
+      "name": "Ngul"
+    },
+    "nlq": {
+      "name": "Lao Naga"
+    },
+    "nlr": {
+      "name": "Ngarla"
+    },
+    "nlu": {
+      "name": "Nchumbulu"
+    },
+    "nlv": {
+      "name": "Orizaba Nahuatl"
+    },
+    "nlw": {
+      "name": "Walangama"
+    },
+    "nlx": {
+      "name": "Nahali"
+    },
+    "nly": {
+      "name": "Nyamal"
+    },
+    "nlz": {
+      "name": "Nalögo"
+    },
+    "nma": {
+      "name": "Maram Naga"
+    },
+    "nmb": {
+      "name": "Big Nambas"
+    },
+    "nmc": {
+      "name": "Ngam"
+    },
+    "nmd": {
+      "name": "Ndumu"
+    },
+    "nme": {
+      "name": "Mzieme Naga"
+    },
+    "nmf": {
+      "name": "Tangkhul Naga (India)"
+    },
+    "nmg": {
+      "name": "Kwasio"
+    },
+    "nmh": {
+      "name": "Monsang Naga"
+    },
+    "nmi": {
+      "name": "Nyam"
+    },
+    "nmj": {
+      "name": "Ngombe (Central African Republic)"
+    },
+    "nmk": {
+      "name": "Namakura"
+    },
+    "nml": {
+      "name": "Ndemli"
+    },
+    "nmm": {
+      "name": "Manangba"
+    },
+    "nmn": {
+      "name": "!Xóõ"
+    },
+    "nmo": {
+      "name": "Moyon Naga"
+    },
+    "nmp": {
+      "name": "Nimanbur"
+    },
+    "nmq": {
+      "name": "Nambya"
+    },
+    "nmr": {
+      "name": "Nimbari"
+    },
+    "nms": {
+      "name": "Letemboi"
+    },
+    "nmt": {
+      "name": "Namonuito"
+    },
+    "nmu": {
+      "name": "Northeast Maidu"
+    },
+    "nmv": {
+      "name": "Ngamini"
+    },
+    "nmw": {
+      "name": "Nimoa"
+    },
+    "nmx": {
+      "name": "Nama (Papua New Guinea)"
+    },
+    "nmy": {
+      "name": "Namuyi"
+    },
+    "nmz": {
+      "name": "Nawdm"
+    },
+    "nna": {
+      "name": "Nyangumarta"
+    },
+    "nnb": {
+      "name": "Nande"
+    },
+    "nnc": {
+      "name": "Nancere"
+    },
+    "nnd": {
+      "name": "West Ambae"
+    },
+    "nne": {
+      "name": "Ngandyera"
+    },
+    "nnf": {
+      "name": "Ngaing"
+    },
+    "nng": {
+      "name": "Maring Naga"
+    },
+    "nnh": {
+      "name": "Ngiemboon"
+    },
+    "nni": {
+      "name": "North Nuaulu"
+    },
+    "nnj": {
+      "name": "Nyangatom"
+    },
+    "nnk": {
+      "name": "Nankina"
+    },
+    "nnl": {
+      "name": "Northern Rengma Naga"
+    },
+    "nnm": {
+      "name": "Namia"
+    },
+    "nnn": {
+      "name": "Ngete"
+    },
+    "nnp": {
+      "name": "Wancho Naga"
+    },
+    "nnq": {
+      "name": "Ngindo"
+    },
+    "nnr": {
+      "name": "Narungga"
+    },
+    "nns": {
+      "name": "Ningye"
+    },
+    "nnt": {
+      "name": "Nanticoke"
+    },
+    "nnu": {
+      "name": "Dwang"
+    },
+    "nnv": {
+      "name": "Nugunu (Australia)"
+    },
+    "nnw": {
+      "name": "Southern Nuni"
+    },
+    "nnx": {
+      "name": "Ngong"
+    },
+    "nny": {
+      "name": "Nyangga"
+    },
+    "nnz": {
+      "name": "Nda'nda'"
+    },
+    "noa": {
+      "name": "Woun Meu"
+    },
+    "noc": {
+      "name": "Nuk"
+    },
+    "nod": {
+      "name": "Northern Thai"
+    },
+    "noe": {
+      "name": "Nimadi"
+    },
+    "nof": {
+      "name": "Nomane"
+    },
+    "nog": {
+      "name": "Nogai"
+    },
+    "noh": {
+      "name": "Nomu"
+    },
+    "noi": {
+      "name": "Noiri"
+    },
+    "noj": {
+      "name": "Nonuya"
+    },
+    "nok": {
+      "name": "Nooksack"
+    },
+    "nol": {
+      "name": "Nomlaki"
+    },
+    "nom": {
+      "name": "Nocamán"
+    },
+    "non": {
+      "name": "Old Norse"
+    },
+    "noo": {
+      "name": "Nootka"
+    },
+    "nop": {
+      "name": "Numanggang"
+    },
+    "noq": {
+      "name": "Ngongo"
+    },
+    "nos": {
+      "name": "Eastern Nisu"
+    },
+    "not": {
+      "name": "Nomatsiguenga"
+    },
+    "nou": {
+      "name": "Ewage-Notu"
+    },
+    "nov": {
+      "name": "Novial"
+    },
+    "now": {
+      "name": "Nyambo"
+    },
+    "noy": {
+      "name": "Noy"
+    },
+    "noz": {
+      "name": "Nayi"
+    },
+    "npa": {
+      "name": "Nar Phu"
+    },
+    "npb": {
+      "name": "Nupbikha"
+    },
+    "npg": {
+      "name": "Ponyo-Gongwang Naga"
+    },
+    "nph": {
+      "name": "Phom Naga"
+    },
+    "npi": {
+      "name": "Nepali (individual language)"
+    },
+    "npl": {
+      "name": "Southeastern Puebla Nahuatl"
+    },
+    "npn": {
+      "name": "Mondropolon"
+    },
+    "npo": {
+      "name": "Pochuri Naga"
+    },
+    "nps": {
+      "name": "Nipsan"
+    },
+    "npu": {
+      "name": "Puimei Naga"
+    },
+    "npx": {
+      "name": "Noipx"
+    },
+    "npy": {
+      "name": "Napu"
+    },
+    "nqg": {
+      "name": "Southern Nago"
+    },
+    "nqk": {
+      "name": "Kura Ede Nago"
+    },
+    "nql": {
+      "name": "Ngendelengo"
+    },
+    "nqm": {
+      "name": "Ndom"
+    },
+    "nqn": {
+      "name": "Nen"
+    },
+    "nqo": {
+      "name": "N'Ko"
+    },
+    "nqq": {
+      "name": "Kyan-Karyaw Naga"
+    },
+    "nqy": {
+      "name": "Akyaung Ari Naga"
+    },
+    "nra": {
+      "name": "Ngom"
+    },
+    "nrb": {
+      "name": "Nara"
+    },
+    "nrc": {
+      "name": "Noric"
+    },
+    "nre": {
+      "name": "Southern Rengma Naga"
+    },
+    "nrf": {
+      "name": "Jèrriais"
+    },
+    "nrg": {
+      "name": "Narango"
+    },
+    "nri": {
+      "name": "Chokri Naga"
+    },
+    "nrk": {
+      "name": "Ngarla"
+    },
+    "nrl": {
+      "name": "Ngarluma"
+    },
+    "nrm": {
+      "name": "Narom"
+    },
+    "nrn": {
+      "name": "Norn"
+    },
+    "nrp": {
+      "name": "North Picene"
+    },
+    "nrr": {
+      "name": "Norra"
+    },
+    "nrt": {
+      "name": "Northern Kalapuya"
+    },
+    "nru": {
+      "name": "Narua"
+    },
+    "nrx": {
+      "name": "Ngurmbur"
+    },
+    "nrz": {
+      "name": "Lala"
+    },
+    "nsa": {
+      "name": "Sangtam Naga"
+    },
+    "nsc": {
+      "name": "Nshi"
+    },
+    "nsd": {
+      "name": "Southern Nisu"
+    },
+    "nse": {
+      "name": "Nsenga"
+    },
+    "nsf": {
+      "name": "Northwestern Nisu"
+    },
+    "nsg": {
+      "name": "Ngasa"
+    },
+    "nsh": {
+      "name": "Ngoshie"
+    },
+    "nsi": {
+      "name": "Nigerian Sign Language"
+    },
+    "nsk": {
+      "name": "Naskapi"
+    },
+    "nsl": {
+      "name": "Norwegian Sign Language"
+    },
+    "nsm": {
+      "name": "Sumi Naga"
+    },
+    "nsn": {
+      "name": "Nehan"
+    },
+    "nso": {
+      "name": "Pedi"
+    },
+    "nsp": {
+      "name": "Nepalese Sign Language"
+    },
+    "nsq": {
+      "name": "Northern Sierra Miwok"
+    },
+    "nsr": {
+      "name": "Maritime Sign Language"
+    },
+    "nss": {
+      "name": "Nali"
+    },
+    "nst": {
+      "name": "Tase Naga"
+    },
+    "nsu": {
+      "name": "Sierra Negra Nahuatl"
+    },
+    "nsv": {
+      "name": "Southwestern Nisu"
+    },
+    "nsw": {
+      "name": "Navut"
+    },
+    "nsx": {
+      "name": "Nsongo"
+    },
+    "nsy": {
+      "name": "Nasal"
+    },
+    "nsz": {
+      "name": "Nisenan"
+    },
+    "ntd": {
+      "name": "Northern Tidung"
+    },
+    "nte": {
+      "name": "Nathembo"
+    },
+    "ntg": {
+      "name": "Ngantangarra"
+    },
+    "nti": {
+      "name": "Natioro"
+    },
+    "ntj": {
+      "name": "Ngaanyatjarra"
+    },
+    "ntk": {
+      "name": "Ikoma-Nata-Isenye"
+    },
+    "ntm": {
+      "name": "Nateni"
+    },
+    "nto": {
+      "name": "Ntomba"
+    },
+    "ntp": {
+      "name": "Northern Tepehuan"
+    },
+    "ntr": {
+      "name": "Delo"
+    },
+    "nts": {
+      "name": "Natagaimas"
+    },
+    "ntu": {
+      "name": "Natügu"
+    },
+    "ntw": {
+      "name": "Nottoway"
+    },
+    "ntx": {
+      "name": "Tangkhul Naga (Myanmar)"
+    },
+    "nty": {
+      "name": "Mantsi"
+    },
+    "ntz": {
+      "name": "Natanzi"
+    },
+    "nua": {
+      "name": "Yuanga"
+    },
+    "nub": {
+      "name": "Nubian languages"
+    },
+    "nuc": {
+      "name": "Nukuini"
+    },
+    "nud": {
+      "name": "Ngala"
+    },
+    "nue": {
+      "name": "Ngundu"
+    },
+    "nuf": {
+      "name": "Nusu"
+    },
+    "nug": {
+      "name": "Nungali"
+    },
+    "nuh": {
+      "name": "Ndunda"
+    },
+    "nui": {
+      "name": "Ngumbi"
+    },
+    "nuj": {
+      "name": "Nyole"
+    },
+    "nuk": {
+      "name": "Nuu-chah-nulth"
+    },
+    "nul": {
+      "name": "Nusa Laut"
+    },
+    "num": {
+      "name": "Niuafo'ou"
+    },
+    "nun": {
+      "name": "Anong"
+    },
+    "nuo": {
+      "name": "Nguôn"
+    },
+    "nup": {
+      "name": "Nupe-Nupe-Tako"
+    },
+    "nuq": {
+      "name": "Nukumanu"
+    },
+    "nur": {
+      "name": "Nukuria"
+    },
+    "nus": {
+      "name": "Nuer"
+    },
+    "nut": {
+      "name": "Nung (Viet Nam)"
+    },
+    "nuu": {
+      "name": "Ngbundu"
+    },
+    "nuv": {
+      "name": "Northern Nuni"
+    },
+    "nuw": {
+      "name": "Nguluwan"
+    },
+    "nux": {
+      "name": "Mehek"
+    },
+    "nuy": {
+      "name": "Nunggubuyu"
+    },
+    "nuz": {
+      "name": "Tlamacazapa Nahuatl"
+    },
+    "nvh": {
+      "name": "Nasarian"
+    },
+    "nvm": {
+      "name": "Namiae"
+    },
+    "nvo": {
+      "name": "Nyokon"
+    },
+    "nwa": {
+      "name": "Nawathinehena"
+    },
+    "nwb": {
+      "name": "Nyabwa"
+    },
+    "nwc": {
+      "name": "Classical Newari"
+    },
+    "nwe": {
+      "name": "Ngwe"
+    },
+    "nwg": {
+      "name": "Ngayawung"
+    },
+    "nwi": {
+      "name": "Southwest Tanna"
+    },
+    "nwm": {
+      "name": "Nyamusa-Molo"
+    },
+    "nwo": {
+      "name": "Nauo"
+    },
+    "nwr": {
+      "name": "Nawaru"
+    },
+    "nwx": {
+      "name": "Middle Newar"
+    },
+    "nwy": {
+      "name": "Nottoway-Meherrin"
+    },
+    "nxa": {
+      "name": "Nauete"
+    },
+    "nxd": {
+      "name": "Ngando (Democratic Republic of Congo)"
+    },
+    "nxe": {
+      "name": "Nage"
+    },
+    "nxg": {
+      "name": "Ngad'a"
+    },
+    "nxi": {
+      "name": "Nindi"
+    },
+    "nxk": {
+      "name": "Koki Naga"
+    },
+    "nxl": {
+      "name": "South Nuaulu"
+    },
+    "nxm": {
+      "name": "Numidian"
+    },
+    "nxn": {
+      "name": "Ngawun"
+    },
+    "nxo": {
+      "name": "Ndambomo"
+    },
+    "nxq": {
+      "name": "Naxi"
+    },
+    "nxr": {
+      "name": "Ninggerum"
+    },
+    "nxu": {
+      "name": "Narau"
+    },
+    "nxx": {
+      "name": "Nafri"
+    },
+    "nyb": {
+      "name": "Nyangbo"
+    },
+    "nyc": {
+      "name": "Nyanga-li"
+    },
+    "nyd": {
+      "name": "Nyore"
+    },
+    "nye": {
+      "name": "Nyengo"
+    },
+    "nyf": {
+      "name": "Giryama"
+    },
+    "nyg": {
+      "name": "Nyindu"
+    },
+    "nyh": {
+      "name": "Nyigina"
+    },
+    "nyi": {
+      "name": "Ama (Sudan)"
+    },
+    "nyj": {
+      "name": "Nyanga"
+    },
+    "nyk": {
+      "name": "Nyaneka"
+    },
+    "nyl": {
+      "name": "Nyeu"
+    },
+    "nym": {
+      "name": "Nyamwezi"
+    },
+    "nyn": {
+      "name": "Nyankole"
+    },
+    "nyo": {
+      "name": "Nyoro"
+    },
+    "nyp": {
+      "name": "Nyang'i"
+    },
+    "nyq": {
+      "name": "Nayini"
+    },
+    "nyr": {
+      "name": "Nyiha (Malawi)"
+    },
+    "nys": {
+      "name": "Nyunga"
+    },
+    "nyt": {
+      "name": "Nyawaygi"
+    },
+    "nyu": {
+      "name": "Nyungwe"
+    },
+    "nyv": {
+      "name": "Nyulnyul"
+    },
+    "nyw": {
+      "name": "Nyaw"
+    },
+    "nyx": {
+      "name": "Nganyaywana"
+    },
+    "nyy": {
+      "name": "Nyakyusa-Ngonde"
+    },
+    "nza": {
+      "name": "Tigon Mbembe"
+    },
+    "nzb": {
+      "name": "Njebi"
+    },
+    "nzd": {
+      "name": "Nzadi"
+    },
+    "nzi": {
+      "name": "Nzima"
+    },
+    "nzk": {
+      "name": "Nzakara"
+    },
+    "nzm": {
+      "name": "Zeme Naga"
+    },
+    "nzs": {
+      "name": "New Zealand Sign Language"
+    },
+    "nzu": {
+      "name": "Teke-Nzikou"
+    },
+    "nzy": {
+      "name": "Nzakambay"
+    },
+    "nzz": {
+      "name": "Nanga Dama Dogon"
+    },
+    "oaa": {
+      "name": "Orok"
+    },
+    "oac": {
+      "name": "Oroch"
+    },
+    "oar": {
+      "name": "Old Aramaic (up to 700 BCE)"
+    },
+    "oav": {
+      "name": "Old Avar"
+    },
+    "obi": {
+      "name": "Obispeño"
+    },
+    "obk": {
+      "name": "Southern Bontok"
+    },
+    "obl": {
+      "name": "Oblo"
+    },
+    "obm": {
+      "name": "Moabite"
+    },
+    "obo": {
+      "name": "Obo Manobo"
+    },
+    "obr": {
+      "name": "Old Burmese"
+    },
+    "obt": {
+      "name": "Old Breton"
+    },
+    "obu": {
+      "name": "Obulom"
+    },
+    "oca": {
+      "name": "Ocaina"
+    },
+    "och": {
+      "name": "Old Chinese"
+    },
+    "oco": {
+      "name": "Old Cornish"
+    },
+    "ocu": {
+      "name": "Atzingo Matlatzinca"
+    },
+    "oda": {
+      "name": "Odut"
+    },
+    "odk": {
+      "name": "Od"
+    },
+    "odt": {
+      "name": "Old Dutch"
+    },
+    "odu": {
+      "name": "Odual"
+    },
+    "ofo": {
+      "name": "Ofo"
+    },
+    "ofs": {
+      "name": "Old Frisian"
+    },
+    "ofu": {
+      "name": "Efutop"
+    },
+    "ogb": {
+      "name": "Ogbia"
+    },
+    "ogc": {
+      "name": "Ogbah"
+    },
+    "oge": {
+      "name": "Old Georgian"
+    },
+    "ogg": {
+      "name": "Ogbogolo"
+    },
+    "ogo": {
+      "name": "Khana"
+    },
+    "ogu": {
+      "name": "Ogbronuagum"
+    },
+    "oht": {
+      "name": "Old Hittite"
+    },
+    "ohu": {
+      "name": "Old Hungarian"
+    },
+    "oia": {
+      "name": "Oirata"
+    },
+    "oin": {
+      "name": "Inebu One"
+    },
+    "ojb": {
+      "name": "Northwestern Ojibwa"
+    },
+    "ojc": {
+      "name": "Central Ojibwa"
+    },
+    "ojg": {
+      "name": "Eastern Ojibwa"
+    },
+    "ojp": {
+      "name": "Old Japanese"
+    },
+    "ojs": {
+      "name": "Severn Ojibwa"
+    },
+    "ojv": {
+      "name": "Ontong Java"
+    },
+    "ojw": {
+      "name": "Western Ojibwa"
+    },
+    "oka": {
+      "name": "Okanagan"
+    },
+    "okb": {
+      "name": "Okobo"
+    },
+    "okd": {
+      "name": "Okodia"
+    },
+    "oke": {
+      "name": "Okpe (Southwestern Edo)"
+    },
+    "okg": {
+      "name": "Koko Babangk"
+    },
+    "okh": {
+      "name": "Koresh-e Rostam"
+    },
+    "oki": {
+      "name": "Okiek"
+    },
+    "okj": {
+      "name": "Oko-Juwoi"
+    },
+    "okk": {
+      "name": "Kwamtim One"
+    },
+    "okl": {
+      "name": "Old Kentish Sign Language"
+    },
+    "okm": {
+      "name": "Middle Korean (10th-16th cent.)"
+    },
+    "okn": {
+      "name": "Oki-No-Erabu"
+    },
+    "oko": {
+      "name": "Old Korean (3rd-9th cent.)"
+    },
+    "okr": {
+      "name": "Kirike"
+    },
+    "oks": {
+      "name": "Oko-Eni-Osayen"
+    },
+    "oku": {
+      "name": "Oku"
+    },
+    "okv": {
+      "name": "Orokaiva"
+    },
+    "okx": {
+      "name": "Okpe (Northwestern Edo)"
+    },
+    "ola": {
+      "name": "Walungge"
+    },
+    "old": {
+      "name": "Mochi"
+    },
+    "ole": {
+      "name": "Olekha"
+    },
+    "olk": {
+      "name": "Olkol"
+    },
+    "olm": {
+      "name": "Oloma"
+    },
+    "olo": {
+      "name": "Livvi"
+    },
+    "olr": {
+      "name": "Olrat"
+    },
+    "olt": {
+      "name": "Old Lithuanian"
+    },
+    "olu": {
+      "name": "Kuvale"
+    },
+    "oma": {
+      "name": "Omaha-Ponca"
+    },
+    "omb": {
+      "name": "East Ambae"
+    },
+    "omc": {
+      "name": "Mochica"
+    },
+    "ome": {
+      "name": "Omejes"
+    },
+    "omg": {
+      "name": "Omagua"
+    },
+    "omi": {
+      "name": "Omi"
+    },
+    "omk": {
+      "name": "Omok"
+    },
+    "oml": {
+      "name": "Ombo"
+    },
+    "omn": {
+      "name": "Minoan"
+    },
+    "omo": {
+      "name": "Utarmbung"
+    },
+    "omp": {
+      "name": "Old Manipuri"
+    },
+    "omq": {
+      "name": "Oto-Manguean languages"
+    },
+    "omr": {
+      "name": "Old Marathi"
+    },
+    "omt": {
+      "name": "Omotik"
+    },
+    "omu": {
+      "name": "Omurano"
+    },
+    "omv": {
+      "name": "Omotic languages"
+    },
+    "omw": {
+      "name": "South Tairora"
+    },
+    "omx": {
+      "name": "Old Mon"
+    },
+    "ona": {
+      "name": "Ona"
+    },
+    "onb": {
+      "name": "Lingao"
+    },
+    "one": {
+      "name": "Oneida"
+    },
+    "ong": {
+      "name": "Olo"
+    },
+    "oni": {
+      "name": "Onin"
+    },
+    "onj": {
+      "name": "Onjob"
+    },
+    "onk": {
+      "name": "Kabore One"
+    },
+    "onn": {
+      "name": "Onobasulu"
+    },
+    "ono": {
+      "name": "Onondaga"
+    },
+    "onp": {
+      "name": "Sartang"
+    },
+    "onr": {
+      "name": "Northern One"
+    },
+    "ons": {
+      "name": "Ono"
+    },
+    "ont": {
+      "name": "Ontenu"
+    },
+    "onu": {
+      "name": "Unua"
+    },
+    "onw": {
+      "name": "Old Nubian"
+    },
+    "onx": {
+      "name": "Onin Based Pidgin"
+    },
+    "ood": {
+      "name": "Tohono O'odham"
+    },
+    "oog": {
+      "name": "Ong"
+    },
+    "oon": {
+      "name": "Önge"
+    },
+    "oor": {
+      "name": "Oorlams"
+    },
+    "oos": {
+      "name": "Old Ossetic"
+    },
+    "opa": {
+      "name": "Okpamheri"
+    },
+    "opk": {
+      "name": "Kopkaka"
+    },
+    "opm": {
+      "name": "Oksapmin"
+    },
+    "opo": {
+      "name": "Opao"
+    },
+    "opt": {
+      "name": "Opata"
+    },
+    "opy": {
+      "name": "Ofayé"
+    },
+    "ora": {
+      "name": "Oroha"
+    },
+    "orc": {
+      "name": "Orma"
+    },
+    "ore": {
+      "name": "Orejón"
+    },
+    "org": {
+      "name": "Oring"
+    },
+    "orh": {
+      "name": "Oroqen"
+    },
+    "orn": {
+      "name": "Orang Kanaq"
+    },
+    "oro": {
+      "name": "Orokolo"
+    },
+    "orr": {
+      "name": "Oruma"
+    },
+    "ors": {
+      "name": "Orang Seletar"
+    },
+    "ort": {
+      "name": "Adivasi Oriya"
+    },
+    "oru": {
+      "name": "Ormuri"
+    },
+    "orv": {
+      "name": "Old Russian"
+    },
+    "orw": {
+      "name": "Oro Win"
+    },
+    "orx": {
+      "name": "Oro"
+    },
+    "ory": {
+      "name": "Odia (individual language)"
+    },
+    "orz": {
+      "name": "Ormu"
+    },
+    "osa": {
+      "name": "Osage"
+    },
+    "osc": {
+      "name": "Oscan"
+    },
+    "osi": {
+      "name": "Osing"
+    },
+    "oso": {
+      "name": "Ososo"
+    },
+    "osp": {
+      "name": "Old Spanish"
+    },
+    "ost": {
+      "name": "Osatu"
+    },
+    "osu": {
+      "name": "Southern One"
+    },
+    "osx": {
+      "name": "Old Saxon"
+    },
+    "ota": {
+      "name": "Ottoman Turkish (1500-1928)"
+    },
+    "otb": {
+      "name": "Old Tibetan"
+    },
+    "otd": {
+      "name": "Ot Danum"
+    },
+    "ote": {
+      "name": "Mezquital Otomi"
+    },
+    "oti": {
+      "name": "Oti"
+    },
+    "otk": {
+      "name": "Old Turkish"
+    },
+    "otl": {
+      "name": "Tilapa Otomi"
+    },
+    "otm": {
+      "name": "Eastern Highland Otomi"
+    },
+    "otn": {
+      "name": "Tenango Otomi"
+    },
+    "oto": {
+      "name": "Otomian languages"
+    },
+    "otq": {
+      "name": "Querétaro Otomi"
+    },
+    "otr": {
+      "name": "Otoro"
+    },
+    "ots": {
+      "name": "Estado de México Otomi"
+    },
+    "ott": {
+      "name": "Temoaya Otomi"
+    },
+    "otu": {
+      "name": "Otuke"
+    },
+    "otw": {
+      "name": "Ottawa"
+    },
+    "otx": {
+      "name": "Texcatepec Otomi"
+    },
+    "oty": {
+      "name": "Old Tamil"
+    },
+    "otz": {
+      "name": "Ixtenco Otomi"
+    },
+    "oua": {
+      "name": "Tagargrent"
+    },
+    "oub": {
+      "name": "Glio-Oubi"
+    },
+    "oue": {
+      "name": "Oune"
+    },
+    "oui": {
+      "name": "Old Uighur"
+    },
+    "oum": {
+      "name": "Ouma"
+    },
+    "oun": {
+      "name": "!O!ung"
+    },
+    "ovd": {
+      "name": "Elfdalian"
+    },
+    "owi": {
+      "name": "Owiniga"
+    },
+    "owl": {
+      "name": "Old Welsh"
+    },
+    "oyb": {
+      "name": "Oy"
+    },
+    "oyd": {
+      "name": "Oyda"
+    },
+    "oym": {
+      "name": "Wayampi"
+    },
+    "oyy": {
+      "name": "Oya'oya"
+    },
+    "ozm": {
+      "name": "Koonzime"
+    },
+    "paa": {
+      "name": "Papuan languages"
+    },
+    "pab": {
+      "name": "Parecís"
+    },
+    "pac": {
+      "name": "Pacoh"
+    },
+    "pad": {
+      "name": "Paumarí"
+    },
+    "pae": {
+      "name": "Pagibete"
+    },
+    "paf": {
+      "name": "Paranawát"
+    },
+    "pag": {
+      "name": "Pangasinan"
+    },
+    "pah": {
+      "name": "Tenharim"
+    },
+    "pai": {
+      "name": "Pe"
+    },
+    "pak": {
+      "name": "Parakanã"
+    },
+    "pal": {
+      "name": "Pahlavi"
+    },
+    "pam": {
+      "name": "Pampanga"
+    },
+    "pao": {
+      "name": "Northern Paiute"
+    },
+    "pap": {
+      "name": "Papiamento"
+    },
+    "paq": {
+      "name": "Parya"
+    },
+    "par": {
+      "name": "Panamint"
+    },
+    "pas": {
+      "name": "Papasena"
+    },
+    "pat": {
+      "name": "Papitalai"
+    },
+    "pau": {
+      "name": "Palauan"
+    },
+    "pav": {
+      "name": "Pakaásnovos"
+    },
+    "paw": {
+      "name": "Pawnee"
+    },
+    "pax": {
+      "name": "Pankararé"
+    },
+    "pay": {
+      "name": "Pech"
+    },
+    "paz": {
+      "name": "Pankararú"
+    },
+    "pbb": {
+      "name": "Páez"
+    },
+    "pbc": {
+      "name": "Patamona"
+    },
+    "pbe": {
+      "name": "Mezontla Popoloca"
+    },
+    "pbf": {
+      "name": "Coyotepec Popoloca"
+    },
+    "pbg": {
+      "name": "Paraujano"
+    },
+    "pbh": {
+      "name": "E'ñapa Woromaipu"
+    },
+    "pbi": {
+      "name": "Parkwa"
+    },
+    "pbl": {
+      "name": "Mak (Nigeria)"
+    },
+    "pbm": {
+      "name": "Puebla Mazatec"
+    },
+    "pbn": {
+      "name": "Kpasam"
+    },
+    "pbo": {
+      "name": "Papel"
+    },
+    "pbp": {
+      "name": "Badyara"
+    },
+    "pbr": {
+      "name": "Pangwa"
+    },
+    "pbs": {
+      "name": "Central Pame"
+    },
+    "pbt": {
+      "name": "Southern Pashto"
+    },
+    "pbu": {
+      "name": "Northern Pashto"
+    },
+    "pbv": {
+      "name": "Pnar"
+    },
+    "pby": {
+      "name": "Pyu (Papua New Guinea)"
+    },
+    "pbz": {
+      "name": "Palu"
+    },
+    "pca": {
+      "name": "Santa Inés Ahuatempan Popoloca"
+    },
+    "pcb": {
+      "name": "Pear"
+    },
+    "pcc": {
+      "name": "Bouyei"
+    },
+    "pcd": {
+      "name": "Picard"
+    },
+    "pce": {
+      "name": "Ruching Palaung"
+    },
+    "pcf": {
+      "name": "Paliyan"
+    },
+    "pcg": {
+      "name": "Paniya"
+    },
+    "pch": {
+      "name": "Pardhan"
+    },
+    "pci": {
+      "name": "Duruwa"
+    },
+    "pcj": {
+      "name": "Parenga"
+    },
+    "pck": {
+      "name": "Paite Chin"
+    },
+    "pcl": {
+      "name": "Pardhi"
+    },
+    "pcm": {
+      "name": "Nigerian Pidgin"
+    },
+    "pcn": {
+      "name": "Piti"
+    },
+    "pcp": {
+      "name": "Pacahuara"
+    },
+    "pcr": {
+      "name": "Panang"
+    },
+    "pcw": {
+      "name": "Pyapun"
+    },
+    "pda": {
+      "name": "Anam"
+    },
+    "pdc": {
+      "name": "Pennsylvania German"
+    },
+    "pdi": {
+      "name": "Pa Di"
+    },
+    "pdn": {
+      "name": "Podena"
+    },
+    "pdo": {
+      "name": "Padoe"
+    },
+    "pdt": {
+      "name": "Plautdietsch"
+    },
+    "pdu": {
+      "name": "Kayan"
+    },
+    "pea": {
+      "name": "Peranakan Indonesian"
+    },
+    "peb": {
+      "name": "Eastern Pomo"
+    },
+    "ped": {
+      "name": "Mala (Papua New Guinea)"
+    },
+    "pee": {
+      "name": "Taje"
+    },
+    "pef": {
+      "name": "Northeastern Pomo"
+    },
+    "peg": {
+      "name": "Pengo"
+    },
+    "peh": {
+      "name": "Bonan"
+    },
+    "pei": {
+      "name": "Chichimeca-Jonaz"
+    },
+    "pej": {
+      "name": "Northern Pomo"
+    },
+    "pek": {
+      "name": "Penchal"
+    },
+    "pel": {
+      "name": "Pekal"
+    },
+    "pem": {
+      "name": "Phende"
+    },
+    "peo": {
+      "name": "Old Persian (ca. 600-400 B.C.)"
+    },
+    "pep": {
+      "name": "Kunja"
+    },
+    "peq": {
+      "name": "Southern Pomo"
+    },
+    "pes": {
+      "name": "Iranian Persian"
+    },
+    "pev": {
+      "name": "Pémono"
+    },
+    "pex": {
+      "name": "Petats"
+    },
+    "pey": {
+      "name": "Petjo"
+    },
+    "pez": {
+      "name": "Eastern Penan"
+    },
+    "pfa": {
+      "name": "Pááfang"
+    },
+    "pfe": {
+      "name": "Peere"
+    },
+    "pfl": {
+      "name": "Pfaelzisch"
+    },
+    "pga": {
+      "name": "Sudanese Creole Arabic"
+    },
+    "pgd": {
+      "name": "Gāndhārī"
+    },
+    "pgg": {
+      "name": "Pangwali"
+    },
+    "pgi": {
+      "name": "Pagi"
+    },
+    "pgk": {
+      "name": "Rerep"
+    },
+    "pgl": {
+      "name": "Primitive Irish"
+    },
+    "pgn": {
+      "name": "Paelignian"
+    },
+    "pgs": {
+      "name": "Pangseng"
+    },
+    "pgu": {
+      "name": "Pagu"
+    },
+    "pgy": {
+      "name": "Pongyong"
+    },
+    "pgz": {
+      "name": "Papua New Guinean Sign Language"
+    },
+    "pha": {
+      "name": "Pa-Hng"
+    },
+    "phd": {
+      "name": "Phudagi"
+    },
+    "phg": {
+      "name": "Phuong"
+    },
+    "phh": {
+      "name": "Phukha"
+    },
+    "phi": {
+      "name": "Philippine languages"
+    },
+    "phk": {
+      "name": "Phake"
+    },
+    "phl": {
+      "name": "Phalura"
+    },
+    "phm": {
+      "name": "Phimbi"
+    },
+    "phn": {
+      "name": "Phoenician"
+    },
+    "pho": {
+      "name": "Phunoi"
+    },
+    "phq": {
+      "name": "Phana'"
+    },
+    "phr": {
+      "name": "Pahari-Potwari"
+    },
+    "pht": {
+      "name": "Phu Thai"
+    },
+    "phu": {
+      "name": "Phuan"
+    },
+    "phv": {
+      "name": "Pahlavani"
+    },
+    "phw": {
+      "name": "Phangduwali"
+    },
+    "pia": {
+      "name": "Pima Bajo"
+    },
+    "pib": {
+      "name": "Yine"
+    },
+    "pic": {
+      "name": "Pinji"
+    },
+    "pid": {
+      "name": "Piaroa"
+    },
+    "pie": {
+      "name": "Piro"
+    },
+    "pif": {
+      "name": "Pingelapese"
+    },
+    "pig": {
+      "name": "Pisabo"
+    },
+    "pih": {
+      "name": "Pitcairn-Norfolk"
+    },
+    "pii": {
+      "name": "Pini"
+    },
+    "pij": {
+      "name": "Pijao"
+    },
+    "pil": {
+      "name": "Yom"
+    },
+    "pim": {
+      "name": "Powhatan"
+    },
+    "pin": {
+      "name": "Piame"
+    },
+    "pio": {
+      "name": "Piapoco"
+    },
+    "pip": {
+      "name": "Pero"
+    },
+    "pir": {
+      "name": "Piratapuyo"
+    },
+    "pis": {
+      "name": "Pijin"
+    },
+    "pit": {
+      "name": "Pitta Pitta"
+    },
+    "piu": {
+      "name": "Pintupi-Luritja"
+    },
+    "piv": {
+      "name": "Pileni"
+    },
+    "piw": {
+      "name": "Pimbwe"
+    },
+    "pix": {
+      "name": "Piu"
+    },
+    "piy": {
+      "name": "Piya-Kwonci"
+    },
+    "piz": {
+      "name": "Pije"
+    },
+    "pjt": {
+      "name": "Pitjantjatjara"
+    },
+    "pka": {
+      "name": "Ardhamāgadhī Prākrit"
+    },
+    "pkb": {
+      "name": "Pokomo"
+    },
+    "pkc": {
+      "name": "Paekche"
+    },
+    "pkg": {
+      "name": "Pak-Tong"
+    },
+    "pkh": {
+      "name": "Pankhu"
+    },
+    "pkn": {
+      "name": "Pakanha"
+    },
+    "pko": {
+      "name": "Pökoot"
+    },
+    "pkp": {
+      "name": "Pukapuka"
+    },
+    "pkr": {
+      "name": "Attapady Kurumba"
+    },
+    "pks": {
+      "name": "Pakistan Sign Language"
+    },
+    "pkt": {
+      "name": "Maleng"
+    },
+    "pku": {
+      "name": "Paku"
+    },
+    "pla": {
+      "name": "Miani"
+    },
+    "plb": {
+      "name": "Polonombauk"
+    },
+    "plc": {
+      "name": "Central Palawano"
+    },
+    "pld": {
+      "name": "Polari"
+    },
+    "ple": {
+      "name": "Palu'e"
+    },
+    "plf": {
+      "name": "Central Malayo-Polynesian languages"
+    },
+    "plg": {
+      "name": "Pilagá"
+    },
+    "plh": {
+      "name": "Paulohi"
+    },
+    "plj": {
+      "name": "Polci"
+    },
+    "plk": {
+      "name": "Kohistani Shina"
+    },
+    "pll": {
+      "name": "Shwe Palaung"
+    },
+    "pln": {
+      "name": "Palenquero"
+    },
+    "plo": {
+      "name": "Oluta Popoluca"
+    },
+    "plp": {
+      "name": "Palpa"
+    },
+    "plq": {
+      "name": "Palaic"
+    },
+    "plr": {
+      "name": "Palaka Senoufo"
+    },
+    "pls": {
+      "name": "San Marcos Tlacoyalco Popoloca"
+    },
+    "plt": {
+      "name": "Plateau Malagasy"
+    },
+    "plu": {
+      "name": "Palikúr"
+    },
+    "plv": {
+      "name": "Southwest Palawano"
+    },
+    "plw": {
+      "name": "Brooke's Point Palawano"
+    },
+    "ply": {
+      "name": "Bolyu"
+    },
+    "plz": {
+      "name": "Paluan"
+    },
+    "pma": {
+      "name": "Paama"
+    },
+    "pmb": {
+      "name": "Pambia"
+    },
+    "pmc": {
+      "name": "Palumata"
+    },
+    "pmd": {
+      "name": "Pallanganmiddang"
+    },
+    "pme": {
+      "name": "Pwaamei"
+    },
+    "pmf": {
+      "name": "Pamona"
+    },
+    "pmh": {
+      "name": "Māhārāṣṭri Prākrit"
+    },
+    "pmi": {
+      "name": "Northern Pumi"
+    },
+    "pmj": {
+      "name": "Southern Pumi"
+    },
+    "pmk": {
+      "name": "Pamlico"
+    },
+    "pml": {
+      "name": "Lingua Franca"
+    },
+    "pmm": {
+      "name": "Pomo"
+    },
+    "pmn": {
+      "name": "Pam"
+    },
+    "pmo": {
+      "name": "Pom"
+    },
+    "pmq": {
+      "name": "Northern Pame"
+    },
+    "pmr": {
+      "name": "Paynamar"
+    },
+    "pms": {
+      "name": "Piemontese"
+    },
+    "pmt": {
+      "name": "Tuamotuan"
+    },
+    "pmu": {
+      "name": "Mirpur Panjabi"
+    },
+    "pmw": {
+      "name": "Plains Miwok"
+    },
+    "pmx": {
+      "name": "Poumei Naga"
+    },
+    "pmy": {
+      "name": "Papuan Malay"
+    },
+    "pmz": {
+      "name": "Southern Pame"
+    },
+    "pna": {
+      "name": "Punan Bah-Biau"
+    },
+    "pnb": {
+      "name": "Western Panjabi"
+    },
+    "pnc": {
+      "name": "Pannei"
+    },
+    "pne": {
+      "name": "Western Penan"
+    },
+    "png": {
+      "name": "Pongu"
+    },
+    "pnh": {
+      "name": "Penrhyn"
+    },
+    "pni": {
+      "name": "Aoheng"
+    },
+    "pnj": {
+      "name": "Pinjarup"
+    },
+    "pnk": {
+      "name": "Paunaka"
+    },
+    "pnl": {
+      "name": "Paleni"
+    },
+    "pnm": {
+      "name": "Punan Batu 1"
+    },
+    "pnn": {
+      "name": "Pinai-Hagahai"
+    },
+    "pno": {
+      "name": "Panobo"
+    },
+    "pnp": {
+      "name": "Pancana"
+    },
+    "pnq": {
+      "name": "Pana (Burkina Faso)"
+    },
+    "pnr": {
+      "name": "Panim"
+    },
+    "pns": {
+      "name": "Ponosakan"
+    },
+    "pnt": {
+      "name": "Pontic"
+    },
+    "pnu": {
+      "name": "Jiongnai Bunu"
+    },
+    "pnv": {
+      "name": "Pinigura"
+    },
+    "pnw": {
+      "name": "Panytyima"
+    },
+    "pnx": {
+      "name": "Phong-Kniang"
+    },
+    "pny": {
+      "name": "Pinyin"
+    },
+    "pnz": {
+      "name": "Pana (Central African Republic)"
+    },
+    "poc": {
+      "name": "Poqomam"
+    },
+    "pod": {
+      "name": "Ponares"
+    },
+    "poe": {
+      "name": "San Juan Atzingo Popoloca"
+    },
+    "pof": {
+      "name": "Poke"
+    },
+    "pog": {
+      "name": "Potiguára"
+    },
+    "poh": {
+      "name": "Poqomchi'"
+    },
+    "poi": {
+      "name": "Highland Popoluca"
+    },
+    "pok": {
+      "name": "Pokangá"
+    },
+    "pom": {
+      "name": "Southeastern Pomo"
+    },
+    "pon": {
+      "name": "Pohnpeian"
+    },
+    "poo": {
+      "name": "Central Pomo"
+    },
+    "pop": {
+      "name": "Pwapwâ"
+    },
+    "poq": {
+      "name": "Texistepec Popoluca"
+    },
+    "pos": {
+      "name": "Sayula Popoluca"
+    },
+    "pot": {
+      "name": "Potawatomi"
+    },
+    "pov": {
+      "name": "Upper Guinea Crioulo"
+    },
+    "pow": {
+      "name": "San Felipe Otlaltepec Popoloca"
+    },
+    "pox": {
+      "name": "Polabian"
+    },
+    "poy": {
+      "name": "Pogolo"
+    },
+    "poz": {
+      "name": "Malayo-Polynesian languages"
+    },
+    "ppa": {
+      "name": "Pao"
+    },
+    "ppe": {
+      "name": "Papi"
+    },
+    "ppi": {
+      "name": "Paipai"
+    },
+    "ppk": {
+      "name": "Uma"
+    },
+    "ppl": {
+      "name": "Pipil"
+    },
+    "ppm": {
+      "name": "Papuma"
+    },
+    "ppn": {
+      "name": "Papapana"
+    },
+    "ppo": {
+      "name": "Folopa"
+    },
+    "ppp": {
+      "name": "Pelende"
+    },
+    "ppq": {
+      "name": "Pei"
+    },
+    "ppr": {
+      "name": "Piru"
+    },
+    "pps": {
+      "name": "San Luís Temalacayuca Popoloca"
+    },
+    "ppt": {
+      "name": "Pare"
+    },
+    "ppu": {
+      "name": "Papora"
+    },
+    "pqa": {
+      "name": "Pa'a"
+    },
+    "pqe": {
+      "name": "Eastern Malayo-Polynesian languages"
+    },
+    "pqm": {
+      "name": "Malecite-Passamaquoddy"
+    },
+    "pqw": {
+      "name": "Western Malayo-Polynesian languages"
+    },
+    "pra": {
+      "name": "Prakrit languages"
+    },
+    "prb": {
+      "name": "Lua'"
+    },
+    "prc": {
+      "name": "Parachi"
+    },
+    "prd": {
+      "name": "Parsi-Dari"
+    },
+    "pre": {
+      "name": "Principense"
+    },
+    "prf": {
+      "name": "Paranan"
+    },
+    "prg": {
+      "name": "Prussian"
+    },
+    "prh": {
+      "name": "Porohanon"
+    },
+    "pri": {
+      "name": "Paicî"
+    },
+    "prk": {
+      "name": "Parauk"
+    },
+    "prl": {
+      "name": "Peruvian Sign Language"
+    },
+    "prm": {
+      "name": "Kibiri"
+    },
+    "prn": {
+      "name": "Prasuni"
+    },
+    "pro": {
+      "name": "Old Provençal (to 1500)"
+    },
+    "prp": {
+      "name": "Parsi"
+    },
+    "prq": {
+      "name": "Ashéninka Perené"
+    },
+    "prr": {
+      "name": "Puri"
+    },
+    "prs": {
+      "name": "Dari"
+    },
+    "prt": {
+      "name": "Phai"
+    },
+    "pru": {
+      "name": "Puragi"
+    },
+    "prw": {
+      "name": "Parawen"
+    },
+    "prx": {
+      "name": "Purik"
+    },
+    "pry": {
+      "name": "Pray 3"
+    },
+    "prz": {
+      "name": "Providencia Sign Language"
+    },
+    "psa": {
+      "name": "Asue Awyu"
+    },
+    "psc": {
+      "name": "Persian Sign Language"
+    },
+    "psd": {
+      "name": "Plains Indian Sign Language"
+    },
+    "pse": {
+      "name": "Central Malay"
+    },
+    "psg": {
+      "name": "Penang Sign Language"
+    },
+    "psh": {
+      "name": "Southwest Pashai"
+    },
+    "psi": {
+      "name": "Southeast Pashai"
+    },
+    "psl": {
+      "name": "Puerto Rican Sign Language"
+    },
+    "psm": {
+      "name": "Pauserna"
+    },
+    "psn": {
+      "name": "Panasuan"
+    },
+    "pso": {
+      "name": "Polish Sign Language"
+    },
+    "psp": {
+      "name": "Philippine Sign Language"
+    },
+    "psq": {
+      "name": "Pasi"
+    },
+    "psr": {
+      "name": "Portuguese Sign Language"
+    },
+    "pss": {
+      "name": "Kaulong"
+    },
+    "pst": {
+      "name": "Central Pashto"
+    },
+    "psu": {
+      "name": "Sauraseni Prākrit"
+    },
+    "psw": {
+      "name": "Port Sandwich"
+    },
+    "psy": {
+      "name": "Piscataway"
+    },
+    "pta": {
+      "name": "Pai Tavytera"
+    },
+    "pth": {
+      "name": "Pataxó Hã-Ha-Hãe"
+    },
+    "pti": {
+      "name": "Pintiini"
+    },
+    "ptn": {
+      "name": "Patani"
+    },
+    "pto": {
+      "name": "Zo'é"
+    },
+    "ptp": {
+      "name": "Patep"
+    },
+    "ptq": {
+      "name": "Pattapu"
+    },
+    "ptr": {
+      "name": "Piamatsina"
+    },
+    "ptt": {
+      "name": "Enrekang"
+    },
+    "ptu": {
+      "name": "Bambam"
+    },
+    "ptv": {
+      "name": "Port Vato"
+    },
+    "ptw": {
+      "name": "Pentlatch"
+    },
+    "pty": {
+      "name": "Pathiya"
+    },
+    "pua": {
+      "name": "Western Highland Purepecha"
+    },
+    "pub": {
+      "name": "Purum"
+    },
+    "puc": {
+      "name": "Punan Merap"
+    },
+    "pud": {
+      "name": "Punan Aput"
+    },
+    "pue": {
+      "name": "Puelche"
+    },
+    "puf": {
+      "name": "Punan Merah"
+    },
+    "pug": {
+      "name": "Phuie"
+    },
+    "pui": {
+      "name": "Puinave"
+    },
+    "puj": {
+      "name": "Punan Tubu"
+    },
+    "puk": {
+      "name": "Pu Ko"
+    },
+    "pum": {
+      "name": "Puma"
+    },
+    "puo": {
+      "name": "Puoc"
+    },
+    "pup": {
+      "name": "Pulabu"
+    },
+    "puq": {
+      "name": "Puquina"
+    },
+    "pur": {
+      "name": "Puruborá"
+    },
+    "put": {
+      "name": "Putoh"
+    },
+    "puu": {
+      "name": "Punu"
+    },
+    "puw": {
+      "name": "Puluwatese"
+    },
+    "pux": {
+      "name": "Puare"
+    },
+    "puy": {
+      "name": "Purisimeño"
+    },
+    "puz": {
+      "name": "Purum Naga"
+    },
+    "pwa": {
+      "name": "Pawaia"
+    },
+    "pwb": {
+      "name": "Panawa"
+    },
+    "pwg": {
+      "name": "Gapapaiwa"
+    },
+    "pwi": {
+      "name": "Patwin"
+    },
+    "pwm": {
+      "name": "Molbog"
+    },
+    "pwn": {
+      "name": "Paiwan"
+    },
+    "pwo": {
+      "name": "Pwo Western Karen"
+    },
+    "pwr": {
+      "name": "Powari"
+    },
+    "pww": {
+      "name": "Pwo Northern Karen"
+    },
+    "pxm": {
+      "name": "Quetzaltepec Mixe"
+    },
+    "pye": {
+      "name": "Pye Krumen"
+    },
+    "pym": {
+      "name": "Fyam"
+    },
+    "pyn": {
+      "name": "Poyanáwa"
+    },
+    "pys": {
+      "name": "Paraguayan Sign Language"
+    },
+    "pyu": {
+      "name": "Puyuma"
+    },
+    "pyx": {
+      "name": "Pyu (Myanmar)"
+    },
+    "pyy": {
+      "name": "Pyen"
+    },
+    "pzn": {
+      "name": "Para Naga"
+    },
+    "qaa..qtz": {
+      "name": "Private use"
+    },
+    "qua": {
+      "name": "Quapaw"
+    },
+    "qub": {
+      "name": "Huallaga Huánuco Quechua"
+    },
+    "quc": {
+      "name": "K'iche'"
+    },
+    "qud": {
+      "name": "Calderón Highland Quichua"
+    },
+    "quf": {
+      "name": "Lambayeque Quechua"
+    },
+    "qug": {
+      "name": "Chimborazo Highland Quichua"
+    },
+    "quh": {
+      "name": "South Bolivian Quechua"
+    },
+    "qui": {
+      "name": "Quileute"
+    },
+    "quk": {
+      "name": "Chachapoyas Quechua"
+    },
+    "qul": {
+      "name": "North Bolivian Quechua"
+    },
+    "qum": {
+      "name": "Sipacapense"
+    },
+    "qun": {
+      "name": "Quinault"
+    },
+    "qup": {
+      "name": "Southern Pastaza Quechua"
+    },
+    "quq": {
+      "name": "Quinqui"
+    },
+    "qur": {
+      "name": "Yanahuanca Pasco Quechua"
+    },
+    "qus": {
+      "name": "Santiago del Estero Quichua"
+    },
+    "quv": {
+      "name": "Sacapulteco"
+    },
+    "quw": {
+      "name": "Tena Lowland Quichua"
+    },
+    "qux": {
+      "name": "Yauyos Quechua"
+    },
+    "quy": {
+      "name": "Ayacucho Quechua"
+    },
+    "quz": {
+      "name": "Cusco Quechua"
+    },
+    "qva": {
+      "name": "Ambo-Pasco Quechua"
+    },
+    "qvc": {
+      "name": "Cajamarca Quechua"
+    },
+    "qve": {
+      "name": "Eastern Apurímac Quechua"
+    },
+    "qvh": {
+      "name": "Huamalíes-Dos de Mayo Huánuco Quechua"
+    },
+    "qvi": {
+      "name": "Imbabura Highland Quichua"
+    },
+    "qvj": {
+      "name": "Loja Highland Quichua"
+    },
+    "qvl": {
+      "name": "Cajatambo North Lima Quechua"
+    },
+    "qvm": {
+      "name": "Margos-Yarowilca-Lauricocha Quechua"
+    },
+    "qvn": {
+      "name": "North Junín Quechua"
+    },
+    "qvo": {
+      "name": "Napo Lowland Quechua"
+    },
+    "qvp": {
+      "name": "Pacaraos Quechua"
+    },
+    "qvs": {
+      "name": "San Martín Quechua"
+    },
+    "qvw": {
+      "name": "Huaylla Wanca Quechua"
+    },
+    "qvy": {
+      "name": "Queyu"
+    },
+    "qvz": {
+      "name": "Northern Pastaza Quichua"
+    },
+    "qwa": {
+      "name": "Corongo Ancash Quechua"
+    },
+    "qwc": {
+      "name": "Classical Quechua"
+    },
+    "qwe": {
+      "name": "Quechuan (family)"
+    },
+    "qwh": {
+      "name": "Huaylas Ancash Quechua"
+    },
+    "qwm": {
+      "name": "Kuman (Russia)"
+    },
+    "qws": {
+      "name": "Sihuas Ancash Quechua"
+    },
+    "qwt": {
+      "name": "Kwalhioqua-Tlatskanai"
+    },
+    "qxa": {
+      "name": "Chiquián Ancash Quechua"
+    },
+    "qxc": {
+      "name": "Chincha Quechua"
+    },
+    "qxh": {
+      "name": "Panao Huánuco Quechua"
+    },
+    "qxl": {
+      "name": "Salasaca Highland Quichua"
+    },
+    "qxn": {
+      "name": "Northern Conchucos Ancash Quechua"
+    },
+    "qxo": {
+      "name": "Southern Conchucos Ancash Quechua"
+    },
+    "qxp": {
+      "name": "Puno Quechua"
+    },
+    "qxq": {
+      "name": "Qashqa'i"
+    },
+    "qxr": {
+      "name": "Cañar Highland Quichua"
+    },
+    "qxs": {
+      "name": "Southern Qiang"
+    },
+    "qxt": {
+      "name": "Santa Ana de Tusi Pasco Quechua"
+    },
+    "qxu": {
+      "name": "Arequipa-La Unión Quechua"
+    },
+    "qxw": {
+      "name": "Jauja Wanca Quechua"
+    },
+    "qya": {
+      "name": "Quenya"
+    },
+    "qyp": {
+      "name": "Quiripi"
+    },
+    "raa": {
+      "name": "Dungmali"
+    },
+    "rab": {
+      "name": "Camling"
+    },
+    "rac": {
+      "name": "Rasawa"
+    },
+    "rad": {
+      "name": "Rade"
+    },
+    "raf": {
+      "name": "Western Meohang"
+    },
+    "rag": {
+      "name": "Logooli"
+    },
+    "rah": {
+      "name": "Rabha"
+    },
+    "rai": {
+      "name": "Ramoaaina"
+    },
+    "raj": {
+      "name": "Rajasthani"
+    },
+    "rak": {
+      "name": "Tulu-Bohuai"
+    },
+    "ral": {
+      "name": "Ralte"
+    },
+    "ram": {
+      "name": "Canela"
+    },
+    "ran": {
+      "name": "Riantana"
+    },
+    "rao": {
+      "name": "Rao"
+    },
+    "rap": {
+      "name": "Rapanui"
+    },
+    "raq": {
+      "name": "Saam"
+    },
+    "rar": {
+      "name": "Rarotongan"
+    },
+    "ras": {
+      "name": "Tegali"
+    },
+    "rat": {
+      "name": "Razajerdi"
+    },
+    "rau": {
+      "name": "Raute"
+    },
+    "rav": {
+      "name": "Sampang"
+    },
+    "raw": {
+      "name": "Rawang"
+    },
+    "rax": {
+      "name": "Rang"
+    },
+    "ray": {
+      "name": "Rapa"
+    },
+    "raz": {
+      "name": "Rahambuu"
+    },
+    "rbb": {
+      "name": "Rumai Palaung"
+    },
+    "rbk": {
+      "name": "Northern Bontok"
+    },
+    "rbl": {
+      "name": "Miraya Bikol"
+    },
+    "rbp": {
+      "name": "Barababaraba"
+    },
+    "rcf": {
+      "name": "Réunion Creole French"
+    },
+    "rdb": {
+      "name": "Rudbari"
+    },
+    "rea": {
+      "name": "Rerau"
+    },
+    "reb": {
+      "name": "Rembong"
+    },
+    "ree": {
+      "name": "Rejang Kayan"
+    },
+    "reg": {
+      "name": "Kara (Tanzania)"
+    },
+    "rei": {
+      "name": "Reli"
+    },
+    "rej": {
+      "name": "Rejang"
+    },
+    "rel": {
+      "name": "Rendille"
+    },
+    "rem": {
+      "name": "Remo"
+    },
+    "ren": {
+      "name": "Rengao"
+    },
+    "rer": {
+      "name": "Rer Bare"
+    },
+    "res": {
+      "name": "Reshe"
+    },
+    "ret": {
+      "name": "Retta"
+    },
+    "rey": {
+      "name": "Reyesano"
+    },
+    "rga": {
+      "name": "Roria"
+    },
+    "rge": {
+      "name": "Romano-Greek"
+    },
+    "rgk": {
+      "name": "Rangkas"
+    },
+    "rgn": {
+      "name": "Romagnol"
+    },
+    "rgr": {
+      "name": "Resígaro"
+    },
+    "rgs": {
+      "name": "Southern Roglai"
+    },
+    "rgu": {
+      "name": "Ringgou"
+    },
+    "rhg": {
+      "name": "Rohingya"
+    },
+    "rhp": {
+      "name": "Yahang"
+    },
+    "ria": {
+      "name": "Riang (India)"
+    },
+    "rie": {
+      "name": "Rien"
+    },
+    "rif": {
+      "name": "Tarifit"
+    },
+    "ril": {
+      "name": "Riang (Myanmar)"
+    },
+    "rim": {
+      "name": "Nyaturu"
+    },
+    "rin": {
+      "name": "Nungu"
+    },
+    "rir": {
+      "name": "Ribun"
+    },
+    "rit": {
+      "name": "Ritarungo"
+    },
+    "riu": {
+      "name": "Riung"
+    },
+    "rjg": {
+      "name": "Rajong"
+    },
+    "rji": {
+      "name": "Raji"
+    },
+    "rjs": {
+      "name": "Rajbanshi"
+    },
+    "rka": {
+      "name": "Kraol"
+    },
+    "rkb": {
+      "name": "Rikbaktsa"
+    },
+    "rkh": {
+      "name": "Rakahanga-Manihiki"
+    },
+    "rki": {
+      "name": "Rakhine"
+    },
+    "rkm": {
+      "name": "Marka"
+    },
+    "rkt": {
+      "name": "Rangpuri"
+    },
+    "rkw": {
+      "name": "Arakwal"
+    },
+    "rma": {
+      "name": "Rama"
+    },
+    "rmb": {
+      "name": "Rembarunga"
+    },
+    "rmc": {
+      "name": "Carpathian Romani"
+    },
+    "rmd": {
+      "name": "Traveller Danish"
+    },
+    "rme": {
+      "name": "Angloromani"
+    },
+    "rmf": {
+      "name": "Kalo Finnish Romani"
+    },
+    "rmg": {
+      "name": "Traveller Norwegian"
+    },
+    "rmh": {
+      "name": "Murkim"
+    },
+    "rmi": {
+      "name": "Lomavren"
+    },
+    "rmk": {
+      "name": "Romkun"
+    },
+    "rml": {
+      "name": "Baltic Romani"
+    },
+    "rmm": {
+      "name": "Roma"
+    },
+    "rmn": {
+      "name": "Balkan Romani"
+    },
+    "rmo": {
+      "name": "Sinte Romani"
+    },
+    "rmp": {
+      "name": "Rempi"
+    },
+    "rmq": {
+      "name": "Caló"
+    },
+    "rmr": {
+      "name": "Caló"
+    },
+    "rms": {
+      "name": "Romanian Sign Language"
+    },
+    "rmt": {
+      "name": "Domari"
+    },
+    "rmu": {
+      "name": "Tavringer Romani"
+    },
+    "rmv": {
+      "name": "Romanova"
+    },
+    "rmw": {
+      "name": "Welsh Romani"
+    },
+    "rmx": {
+      "name": "Romam"
+    },
+    "rmy": {
+      "name": "Vlax Romani"
+    },
+    "rmz": {
+      "name": "Marma"
+    },
+    "rna": {
+      "name": "Runa"
+    },
+    "rnd": {
+      "name": "Ruund"
+    },
+    "rng": {
+      "name": "Ronga"
+    },
+    "rnl": {
+      "name": "Ranglong"
+    },
+    "rnn": {
+      "name": "Roon"
+    },
+    "rnp": {
+      "name": "Rongpo"
+    },
+    "rnr": {
+      "name": "Nari Nari"
+    },
+    "rnw": {
+      "name": "Rungwa"
+    },
+    "roa": {
+      "name": "Romance languages"
+    },
+    "rob": {
+      "name": "Tae'"
+    },
+    "roc": {
+      "name": "Cacgia Roglai"
+    },
+    "rod": {
+      "name": "Rogo"
+    },
+    "roe": {
+      "name": "Ronji"
+    },
+    "rof": {
+      "name": "Rombo"
+    },
+    "rog": {
+      "name": "Northern Roglai"
+    },
+    "rol": {
+      "name": "Romblomanon"
+    },
+    "rom": {
+      "name": "Romany"
+    },
+    "roo": {
+      "name": "Rotokas"
+    },
+    "rop": {
+      "name": "Kriol"
+    },
+    "ror": {
+      "name": "Rongga"
+    },
+    "rou": {
+      "name": "Runga"
+    },
+    "row": {
+      "name": "Dela-Oenale"
+    },
+    "rpn": {
+      "name": "Repanbitip"
+    },
+    "rpt": {
+      "name": "Rapting"
+    },
+    "rri": {
+      "name": "Ririo"
+    },
+    "rro": {
+      "name": "Waima"
+    },
+    "rrt": {
+      "name": "Arritinngithigh"
+    },
+    "rsb": {
+      "name": "Romano-Serbian"
+    },
+    "rsi": {
+      "name": "Rennellese Sign Language"
+    },
+    "rsl": {
+      "name": "Russian Sign Language"
+    },
+    "rsm": {
+      "name": "Miriwoong Sign Language"
+    },
+    "rtc": {
+      "name": "Rungtu Chin"
+    },
+    "rth": {
+      "name": "Ratahan"
+    },
+    "rtm": {
+      "name": "Rotuman"
+    },
+    "rts": {
+      "name": "Yurats"
+    },
+    "rtw": {
+      "name": "Rathawi"
+    },
+    "rub": {
+      "name": "Gungu"
+    },
+    "ruc": {
+      "name": "Ruuli"
+    },
+    "rue": {
+      "name": "Rusyn"
+    },
+    "ruf": {
+      "name": "Luguru"
+    },
+    "rug": {
+      "name": "Roviana"
+    },
+    "ruh": {
+      "name": "Ruga"
+    },
+    "rui": {
+      "name": "Rufiji"
+    },
+    "ruk": {
+      "name": "Che"
+    },
+    "ruo": {
+      "name": "Istro Romanian"
+    },
+    "rup": {
+      "name": "Macedo-Romanian"
+    },
+    "ruq": {
+      "name": "Megleno Romanian"
+    },
+    "rut": {
+      "name": "Rutul"
+    },
+    "ruu": {
+      "name": "Lanas Lobu"
+    },
+    "ruy": {
+      "name": "Mala (Nigeria)"
+    },
+    "ruz": {
+      "name": "Ruma"
+    },
+    "rwa": {
+      "name": "Rawo"
+    },
+    "rwk": {
+      "name": "Rwa"
+    },
+    "rwm": {
+      "name": "Amba (Uganda)"
+    },
+    "rwo": {
+      "name": "Rawa"
+    },
+    "rwr": {
+      "name": "Marwari (India)"
+    },
+    "rxd": {
+      "name": "Ngardi"
+    },
+    "rxw": {
+      "name": "Karuwali"
+    },
+    "ryn": {
+      "name": "Northern Amami-Oshima"
+    },
+    "rys": {
+      "name": "Yaeyama"
+    },
+    "ryu": {
+      "name": "Central Okinawan"
+    },
+    "rzh": {
+      "name": "Rāziḥī"
+    },
+    "saa": {
+      "name": "Saba"
+    },
+    "sab": {
+      "name": "Buglere"
+    },
+    "sac": {
+      "name": "Meskwaki"
+    },
+    "sad": {
+      "name": "Sandawe"
+    },
+    "sae": {
+      "name": "Sabanê"
+    },
+    "saf": {
+      "name": "Safaliba"
+    },
+    "sah": {
+      "name": "Yakut"
+    },
+    "sai": {
+      "name": "South American Indian languages"
+    },
+    "saj": {
+      "name": "Sahu"
+    },
+    "sak": {
+      "name": "Sake"
+    },
+    "sal": {
+      "name": "Salishan languages"
+    },
+    "sam": {
+      "name": "Samaritan Aramaic"
+    },
+    "sao": {
+      "name": "Sause"
+    },
+    "sap": {
+      "name": "Sanapaná"
+    },
+    "saq": {
+      "name": "Samburu"
+    },
+    "sar": {
+      "name": "Saraveca"
+    },
+    "sas": {
+      "name": "Sasak"
+    },
+    "sat": {
+      "name": "Santali"
+    },
+    "sau": {
+      "name": "Saleman"
+    },
+    "sav": {
+      "name": "Saafi-Saafi"
+    },
+    "saw": {
+      "name": "Sawi"
+    },
+    "sax": {
+      "name": "Sa"
+    },
+    "say": {
+      "name": "Saya"
+    },
+    "saz": {
+      "name": "Saurashtra"
+    },
+    "sba": {
+      "name": "Ngambay"
+    },
+    "sbb": {
+      "name": "Simbo"
+    },
+    "sbc": {
+      "name": "Kele (Papua New Guinea)"
+    },
+    "sbd": {
+      "name": "Southern Samo"
+    },
+    "sbe": {
+      "name": "Saliba"
+    },
+    "sbf": {
+      "name": "Chabu"
+    },
+    "sbg": {
+      "name": "Seget"
+    },
+    "sbh": {
+      "name": "Sori-Harengan"
+    },
+    "sbi": {
+      "name": "Seti"
+    },
+    "sbj": {
+      "name": "Surbakhal"
+    },
+    "sbk": {
+      "name": "Safwa"
+    },
+    "sbl": {
+      "name": "Botolan Sambal"
+    },
+    "sbm": {
+      "name": "Sagala"
+    },
+    "sbn": {
+      "name": "Sindhi Bhil"
+    },
+    "sbo": {
+      "name": "Sabüm"
+    },
+    "sbp": {
+      "name": "Sangu (Tanzania)"
+    },
+    "sbq": {
+      "name": "Sileibi"
+    },
+    "sbr": {
+      "name": "Sembakung Murut"
+    },
+    "sbs": {
+      "name": "Subiya"
+    },
+    "sbt": {
+      "name": "Kimki"
+    },
+    "sbu": {
+      "name": "Stod Bhoti"
+    },
+    "sbv": {
+      "name": "Sabine"
+    },
+    "sbw": {
+      "name": "Simba"
+    },
+    "sbx": {
+      "name": "Seberuang"
+    },
+    "sby": {
+      "name": "Soli"
+    },
+    "sbz": {
+      "name": "Sara Kaba"
+    },
+    "sca": {
+      "name": "Sansu"
+    },
+    "scb": {
+      "name": "Chut"
+    },
+    "sce": {
+      "name": "Dongxiang"
+    },
+    "scf": {
+      "name": "San Miguel Creole French"
+    },
+    "scg": {
+      "name": "Sanggau"
+    },
+    "sch": {
+      "name": "Sakachep"
+    },
+    "sci": {
+      "name": "Sri Lankan Creole Malay"
+    },
+    "sck": {
+      "name": "Sadri"
+    },
+    "scl": {
+      "name": "Shina"
+    },
+    "scn": {
+      "name": "Sicilian"
+    },
+    "sco": {
+      "name": "Scots"
+    },
+    "scp": {
+      "name": "Hyolmo"
+    },
+    "scq": {
+      "name": "Sa'och"
+    },
+    "scs": {
+      "name": "North Slavey"
+    },
+    "sct": {
+      "name": "Southern Katang"
+    },
+    "scu": {
+      "name": "Shumcho"
+    },
+    "scv": {
+      "name": "Sheni"
+    },
+    "scw": {
+      "name": "Sha"
+    },
+    "scx": {
+      "name": "Sicel"
+    },
+    "sda": {
+      "name": "Toraja-Sa'dan"
+    },
+    "sdb": {
+      "name": "Shabak"
+    },
+    "sdc": {
+      "name": "Sassarese Sardinian"
+    },
+    "sde": {
+      "name": "Surubu"
+    },
+    "sdf": {
+      "name": "Sarli"
+    },
+    "sdg": {
+      "name": "Savi"
+    },
+    "sdh": {
+      "name": "Southern Kurdish"
+    },
+    "sdj": {
+      "name": "Suundi"
+    },
+    "sdk": {
+      "name": "Sos Kundi"
+    },
+    "sdl": {
+      "name": "Saudi Arabian Sign Language"
+    },
+    "sdm": {
+      "name": "Semandang"
+    },
+    "sdn": {
+      "name": "Gallurese Sardinian"
+    },
+    "sdo": {
+      "name": "Bukar-Sadung Bidayuh"
+    },
+    "sdp": {
+      "name": "Sherdukpen"
+    },
+    "sdr": {
+      "name": "Oraon Sadri"
+    },
+    "sds": {
+      "name": "Sened"
+    },
+    "sdt": {
+      "name": "Shuadit"
+    },
+    "sdu": {
+      "name": "Sarudu"
+    },
+    "sdv": {
+      "name": "Eastern Sudanic languages"
+    },
+    "sdx": {
+      "name": "Sibu Melanau"
+    },
+    "sdz": {
+      "name": "Sallands"
+    },
+    "sea": {
+      "name": "Semai"
+    },
+    "seb": {
+      "name": "Shempire Senoufo"
+    },
+    "sec": {
+      "name": "Sechelt"
+    },
+    "sed": {
+      "name": "Sedang"
+    },
+    "see": {
+      "name": "Seneca"
+    },
+    "sef": {
+      "name": "Cebaara Senoufo"
+    },
+    "seg": {
+      "name": "Segeju"
+    },
+    "seh": {
+      "name": "Sena"
+    },
+    "sei": {
+      "name": "Seri"
+    },
+    "sej": {
+      "name": "Sene"
+    },
+    "sek": {
+      "name": "Sekani"
+    },
+    "sel": {
+      "name": "Selkup"
+    },
+    "sem": {
+      "name": "Semitic languages"
+    },
+    "sen": {
+      "name": "Nanerigé Sénoufo"
+    },
+    "seo": {
+      "name": "Suarmin"
+    },
+    "sep": {
+      "name": "Sìcìté Sénoufo"
+    },
+    "seq": {
+      "name": "Senara Sénoufo"
+    },
+    "ser": {
+      "name": "Serrano"
+    },
+    "ses": {
+      "name": "Koyraboro Senni Songhai"
+    },
+    "set": {
+      "name": "Sentani"
+    },
+    "seu": {
+      "name": "Serui-Laut"
+    },
+    "sev": {
+      "name": "Nyarafolo Senoufo"
+    },
+    "sew": {
+      "name": "Sewa Bay"
+    },
+    "sey": {
+      "name": "Secoya"
+    },
+    "sez": {
+      "name": "Senthang Chin"
+    },
+    "sfb": {
+      "name": "Langue des signes de Belgique Francophone"
+    },
+    "sfe": {
+      "name": "Eastern Subanen"
+    },
+    "sfm": {
+      "name": "Small Flowery Miao"
+    },
+    "sfs": {
+      "name": "South African Sign Language"
+    },
+    "sfw": {
+      "name": "Sehwi"
+    },
+    "sga": {
+      "name": "Old Irish (to 900)"
+    },
+    "sgb": {
+      "name": "Mag-antsi Ayta"
+    },
+    "sgc": {
+      "name": "Kipsigis"
+    },
+    "sgd": {
+      "name": "Surigaonon"
+    },
+    "sge": {
+      "name": "Segai"
+    },
+    "sgg": {
+      "name": "Swiss-German Sign Language"
+    },
+    "sgh": {
+      "name": "Shughni"
+    },
+    "sgi": {
+      "name": "Suga"
+    },
+    "sgj": {
+      "name": "Surgujia"
+    },
+    "sgk": {
+      "name": "Sangkong"
+    },
+    "sgl": {
+      "name": "Sanglechi-Ishkashimi"
+    },
+    "sgm": {
+      "name": "Singa"
+    },
+    "sgn": {
+      "name": "Sign languages"
+    },
+    "sgo": {
+      "name": "Songa"
+    },
+    "sgp": {
+      "name": "Singpho"
+    },
+    "sgr": {
+      "name": "Sangisari"
+    },
+    "sgs": {
+      "name": "Samogitian"
+    },
+    "sgt": {
+      "name": "Brokpake"
+    },
+    "sgu": {
+      "name": "Salas"
+    },
+    "sgw": {
+      "name": "Sebat Bet Gurage"
+    },
+    "sgx": {
+      "name": "Sierra Leone Sign Language"
+    },
+    "sgy": {
+      "name": "Sanglechi"
+    },
+    "sgz": {
+      "name": "Sursurunga"
+    },
+    "sha": {
+      "name": "Shall-Zwall"
+    },
+    "shb": {
+      "name": "Ninam"
+    },
+    "shc": {
+      "name": "Sonde"
+    },
+    "shd": {
+      "name": "Kundal Shahi"
+    },
+    "she": {
+      "name": "Sheko"
+    },
+    "shg": {
+      "name": "Shua"
+    },
+    "shh": {
+      "name": "Shoshoni"
+    },
+    "shi": {
+      "name": "Tachelhit"
+    },
+    "shj": {
+      "name": "Shatt"
+    },
+    "shk": {
+      "name": "Shilluk"
+    },
+    "shl": {
+      "name": "Shendu"
+    },
+    "shm": {
+      "name": "Shahrudi"
+    },
+    "shn": {
+      "name": "Shan"
+    },
+    "sho": {
+      "name": "Shanga"
+    },
+    "shp": {
+      "name": "Shipibo-Conibo"
+    },
+    "shq": {
+      "name": "Sala"
+    },
+    "shr": {
+      "name": "Shi"
+    },
+    "shs": {
+      "name": "Shuswap"
+    },
+    "sht": {
+      "name": "Shasta"
+    },
+    "shu": {
+      "name": "Chadian Arabic"
+    },
+    "shv": {
+      "name": "Shehri"
+    },
+    "shw": {
+      "name": "Shwai"
+    },
+    "shx": {
+      "name": "She"
+    },
+    "shy": {
+      "name": "Tachawit"
+    },
+    "shz": {
+      "name": "Syenara Senoufo"
+    },
+    "sia": {
+      "name": "Akkala Sami"
+    },
+    "sib": {
+      "name": "Sebop"
+    },
+    "sid": {
+      "name": "Sidamo"
+    },
+    "sie": {
+      "name": "Simaa"
+    },
+    "sif": {
+      "name": "Siamou"
+    },
+    "sig": {
+      "name": "Paasaal"
+    },
+    "sih": {
+      "name": "Zire"
+    },
+    "sii": {
+      "name": "Shom Peng"
+    },
+    "sij": {
+      "name": "Numbami"
+    },
+    "sik": {
+      "name": "Sikiana"
+    },
+    "sil": {
+      "name": "Tumulung Sisaala"
+    },
+    "sim": {
+      "name": "Mende (Papua New Guinea)"
+    },
+    "sio": {
+      "name": "Siouan languages"
+    },
+    "sip": {
+      "name": "Sikkimese"
+    },
+    "siq": {
+      "name": "Sonia"
+    },
+    "sir": {
+      "name": "Siri"
+    },
+    "sis": {
+      "name": "Siuslaw"
+    },
+    "sit": {
+      "name": "Sino-Tibetan languages"
+    },
+    "siu": {
+      "name": "Sinagen"
+    },
+    "siv": {
+      "name": "Sumariup"
+    },
+    "siw": {
+      "name": "Siwai"
+    },
+    "six": {
+      "name": "Sumau"
+    },
+    "siy": {
+      "name": "Sivandi"
+    },
+    "siz": {
+      "name": "Siwi"
+    },
+    "sja": {
+      "name": "Epena"
+    },
+    "sjb": {
+      "name": "Sajau Basap"
+    },
+    "sjd": {
+      "name": "Kildin Sami"
+    },
+    "sje": {
+      "name": "Pite Sami"
+    },
+    "sjg": {
+      "name": "Assangori"
+    },
+    "sjk": {
+      "name": "Kemi Sami"
+    },
+    "sjl": {
+      "name": "Sajalong"
+    },
+    "sjm": {
+      "name": "Mapun"
+    },
+    "sjn": {
+      "name": "Sindarin"
+    },
+    "sjo": {
+      "name": "Xibe"
+    },
+    "sjp": {
+      "name": "Surjapuri"
+    },
+    "sjr": {
+      "name": "Siar-Lak"
+    },
+    "sjs": {
+      "name": "Senhaja De Srair"
+    },
+    "sjt": {
+      "name": "Ter Sami"
+    },
+    "sju": {
+      "name": "Ume Sami"
+    },
+    "sjw": {
+      "name": "Shawnee"
+    },
+    "ska": {
+      "name": "Skagit"
+    },
+    "skb": {
+      "name": "Saek"
+    },
+    "skc": {
+      "name": "Ma Manda"
+    },
+    "skd": {
+      "name": "Southern Sierra Miwok"
+    },
+    "ske": {
+      "name": "Seke (Vanuatu)"
+    },
+    "skf": {
+      "name": "Sakirabiá"
+    },
+    "skg": {
+      "name": "Sakalava Malagasy"
+    },
+    "skh": {
+      "name": "Sikule"
+    },
+    "ski": {
+      "name": "Sika"
+    },
+    "skj": {
+      "name": "Seke (Nepal)"
+    },
+    "skk": {
+      "name": "Sok"
+    },
+    "skm": {
+      "name": "Kutong"
+    },
+    "skn": {
+      "name": "Kolibugan Subanon"
+    },
+    "sko": {
+      "name": "Seko Tengah"
+    },
+    "skp": {
+      "name": "Sekapan"
+    },
+    "skq": {
+      "name": "Sininkere"
+    },
+    "skr": {
+      "name": "Saraiki"
+    },
+    "sks": {
+      "name": "Maia"
+    },
+    "skt": {
+      "name": "Sakata"
+    },
+    "sku": {
+      "name": "Sakao"
+    },
+    "skv": {
+      "name": "Skou"
+    },
+    "skw": {
+      "name": "Skepi Creole Dutch"
+    },
+    "skx": {
+      "name": "Seko Padang"
+    },
+    "sky": {
+      "name": "Sikaiana"
+    },
+    "skz": {
+      "name": "Sekar"
+    },
+    "sla": {
+      "name": "Slavic languages"
+    },
+    "slc": {
+      "name": "Sáliba"
+    },
+    "sld": {
+      "name": "Sissala"
+    },
+    "sle": {
+      "name": "Sholaga"
+    },
+    "slf": {
+      "name": "Swiss-Italian Sign Language"
+    },
+    "slg": {
+      "name": "Selungai Murut"
+    },
+    "slh": {
+      "name": "Southern Puget Sound Salish"
+    },
+    "sli": {
+      "name": "Lower Silesian"
+    },
+    "slj": {
+      "name": "Salumá"
+    },
+    "sll": {
+      "name": "Salt-Yui"
+    },
+    "slm": {
+      "name": "Pangutaran Sama"
+    },
+    "sln": {
+      "name": "Salinan"
+    },
+    "slp": {
+      "name": "Lamaholot"
+    },
+    "slq": {
+      "name": "Salchuq"
+    },
+    "slr": {
+      "name": "Salar"
+    },
+    "sls": {
+      "name": "Singapore Sign Language"
+    },
+    "slt": {
+      "name": "Sila"
+    },
+    "slu": {
+      "name": "Selaru"
+    },
+    "slw": {
+      "name": "Sialum"
+    },
+    "slx": {
+      "name": "Salampasu"
+    },
+    "sly": {
+      "name": "Selayar"
+    },
+    "slz": {
+      "name": "Ma'ya"
+    },
+    "sma": {
+      "name": "Southern Sami"
+    },
+    "smb": {
+      "name": "Simbari"
+    },
+    "smc": {
+      "name": "Som"
+    },
+    "smd": {
+      "name": "Sama"
+    },
+    "smf": {
+      "name": "Auwe"
+    },
+    "smg": {
+      "name": "Simbali"
+    },
+    "smh": {
+      "name": "Samei"
+    },
+    "smi": {
+      "name": "Sami languages"
+    },
+    "smj": {
+      "name": "Lule Sami"
+    },
+    "smk": {
+      "name": "Bolinao"
+    },
+    "sml": {
+      "name": "Central Sama"
+    },
+    "smm": {
+      "name": "Musasa"
+    },
+    "smn": {
+      "name": "Inari Sami"
+    },
+    "smp": {
+      "name": "Samaritan"
+    },
+    "smq": {
+      "name": "Samo"
+    },
+    "smr": {
+      "name": "Simeulue"
+    },
+    "sms": {
+      "name": "Skolt Sami"
+    },
+    "smt": {
+      "name": "Simte"
+    },
+    "smu": {
+      "name": "Somray"
+    },
+    "smv": {
+      "name": "Samvedi"
+    },
+    "smw": {
+      "name": "Sumbawa"
+    },
+    "smx": {
+      "name": "Samba"
+    },
+    "smy": {
+      "name": "Semnani"
+    },
+    "smz": {
+      "name": "Simeku"
+    },
+    "snb": {
+      "name": "Sebuyau"
+    },
+    "snc": {
+      "name": "Sinaugoro"
+    },
+    "sne": {
+      "name": "Bau Bidayuh"
+    },
+    "snf": {
+      "name": "Noon"
+    },
+    "sng": {
+      "name": "Sanga (Democratic Republic of Congo)"
+    },
+    "snh": {
+      "name": "Shinabo"
+    },
+    "sni": {
+      "name": "Sensi"
+    },
+    "snj": {
+      "name": "Riverain Sango"
+    },
+    "snk": {
+      "name": "Soninke"
+    },
+    "snl": {
+      "name": "Sangil"
+    },
+    "snm": {
+      "name": "Southern Ma'di"
+    },
+    "snn": {
+      "name": "Siona"
+    },
+    "sno": {
+      "name": "Snohomish"
+    },
+    "snp": {
+      "name": "Siane"
+    },
+    "snq": {
+      "name": "Sangu (Gabon)"
+    },
+    "snr": {
+      "name": "Sihan"
+    },
+    "sns": {
+      "name": "South West Bay"
+    },
+    "snu": {
+      "name": "Senggi"
+    },
+    "snv": {
+      "name": "Sa'ban"
+    },
+    "snw": {
+      "name": "Selee"
+    },
+    "snx": {
+      "name": "Sam"
+    },
+    "sny": {
+      "name": "Saniyo-Hiyewe"
+    },
+    "snz": {
+      "name": "Sinsauru"
+    },
+    "soa": {
+      "name": "Thai Song"
+    },
+    "sob": {
+      "name": "Sobei"
+    },
+    "soc": {
+      "name": "So (Democratic Republic of Congo)"
+    },
+    "sod": {
+      "name": "Songoora"
+    },
+    "soe": {
+      "name": "Songomeno"
+    },
+    "sog": {
+      "name": "Sogdian"
+    },
+    "soh": {
+      "name": "Aka"
+    },
+    "soi": {
+      "name": "Sonha"
+    },
+    "soj": {
+      "name": "Soi"
+    },
+    "sok": {
+      "name": "Sokoro"
+    },
+    "sol": {
+      "name": "Solos"
+    },
+    "son": {
+      "name": "Songhai languages"
+    },
+    "soo": {
+      "name": "Songo"
+    },
+    "sop": {
+      "name": "Songe"
+    },
+    "soq": {
+      "name": "Kanasi"
+    },
+    "sor": {
+      "name": "Somrai"
+    },
+    "sos": {
+      "name": "Seeku"
+    },
+    "sou": {
+      "name": "Southern Thai"
+    },
+    "sov": {
+      "name": "Sonsorol"
+    },
+    "sow": {
+      "name": "Sowanda"
+    },
+    "sox": {
+      "name": "Swo"
+    },
+    "soy": {
+      "name": "Miyobe"
+    },
+    "soz": {
+      "name": "Temi"
+    },
+    "spb": {
+      "name": "Sepa (Indonesia)"
+    },
+    "spc": {
+      "name": "Sapé"
+    },
+    "spd": {
+      "name": "Saep"
+    },
+    "spe": {
+      "name": "Sepa (Papua New Guinea)"
+    },
+    "spg": {
+      "name": "Sian"
+    },
+    "spi": {
+      "name": "Saponi"
+    },
+    "spk": {
+      "name": "Sengo"
+    },
+    "spl": {
+      "name": "Selepet"
+    },
+    "spm": {
+      "name": "Akukem"
+    },
+    "spn": {
+      "name": "Sanapaná"
+    },
+    "spo": {
+      "name": "Spokane"
+    },
+    "spp": {
+      "name": "Supyire Senoufo"
+    },
+    "spq": {
+      "name": "Loreto-Ucayali Spanish"
+    },
+    "spr": {
+      "name": "Saparua"
+    },
+    "sps": {
+      "name": "Saposa"
+    },
+    "spt": {
+      "name": "Spiti Bhoti"
+    },
+    "spu": {
+      "name": "Sapuan"
+    },
+    "spv": {
+      "name": "Sambalpuri"
+    },
+    "spx": {
+      "name": "South Picene"
+    },
+    "spy": {
+      "name": "Sabaot"
+    },
+    "sqa": {
+      "name": "Shama-Sambuga"
+    },
+    "sqh": {
+      "name": "Shau"
+    },
+    "sqj": {
+      "name": "Albanian languages"
+    },
+    "sqk": {
+      "name": "Albanian Sign Language"
+    },
+    "sqm": {
+      "name": "Suma"
+    },
+    "sqn": {
+      "name": "Susquehannock"
+    },
+    "sqo": {
+      "name": "Sorkhei"
+    },
+    "sqq": {
+      "name": "Sou"
+    },
+    "sqr": {
+      "name": "Siculo Arabic"
+    },
+    "sqs": {
+      "name": "Sri Lankan Sign Language"
+    },
+    "sqt": {
+      "name": "Soqotri"
+    },
+    "squ": {
+      "name": "Squamish"
+    },
+    "sra": {
+      "name": "Saruga"
+    },
+    "srb": {
+      "name": "Sora"
+    },
+    "src": {
+      "name": "Logudorese Sardinian"
+    },
+    "sre": {
+      "name": "Sara"
+    },
+    "srf": {
+      "name": "Nafi"
+    },
+    "srg": {
+      "name": "Sulod"
+    },
+    "srh": {
+      "name": "Sarikoli"
+    },
+    "sri": {
+      "name": "Siriano"
+    },
+    "srk": {
+      "name": "Serudung Murut"
+    },
+    "srl": {
+      "name": "Isirawa"
+    },
+    "srm": {
+      "name": "Saramaccan"
+    },
+    "srn": {
+      "name": "Sranan Tongo"
+    },
+    "sro": {
+      "name": "Campidanese Sardinian"
+    },
+    "srq": {
+      "name": "Sirionó"
+    },
+    "srr": {
+      "name": "Serer"
+    },
+    "srs": {
+      "name": "Sarsi"
+    },
+    "srt": {
+      "name": "Sauri"
+    },
+    "sru": {
+      "name": "Suruí"
+    },
+    "srv": {
+      "name": "Southern Sorsoganon"
+    },
+    "srw": {
+      "name": "Serua"
+    },
+    "srx": {
+      "name": "Sirmauri"
+    },
+    "sry": {
+      "name": "Sera"
+    },
+    "srz": {
+      "name": "Shahmirzadi"
+    },
+    "ssa": {
+      "name": "Nilo-Saharan languages"
+    },
+    "ssb": {
+      "name": "Southern Sama"
+    },
+    "ssc": {
+      "name": "Suba-Simbiti"
+    },
+    "ssd": {
+      "name": "Siroi"
+    },
+    "sse": {
+      "name": "Balangingi"
+    },
+    "ssf": {
+      "name": "Thao"
+    },
+    "ssg": {
+      "name": "Seimat"
+    },
+    "ssh": {
+      "name": "Shihhi Arabic"
+    },
+    "ssi": {
+      "name": "Sansi"
+    },
+    "ssj": {
+      "name": "Sausi"
+    },
+    "ssk": {
+      "name": "Sunam"
+    },
+    "ssl": {
+      "name": "Western Sisaala"
+    },
+    "ssm": {
+      "name": "Semnam"
+    },
+    "ssn": {
+      "name": "Waata"
+    },
+    "sso": {
+      "name": "Sissano"
+    },
+    "ssp": {
+      "name": "Spanish Sign Language"
+    },
+    "ssq": {
+      "name": "So'a"
+    },
+    "ssr": {
+      "name": "Swiss-French Sign Language"
+    },
+    "sss": {
+      "name": "Sô"
+    },
+    "sst": {
+      "name": "Sinasina"
+    },
+    "ssu": {
+      "name": "Susuami"
+    },
+    "ssv": {
+      "name": "Shark Bay"
+    },
+    "ssx": {
+      "name": "Samberigi"
+    },
+    "ssy": {
+      "name": "Saho"
+    },
+    "ssz": {
+      "name": "Sengseng"
+    },
+    "sta": {
+      "name": "Settla"
+    },
+    "stb": {
+      "name": "Northern Subanen"
+    },
+    "std": {
+      "name": "Sentinel"
+    },
+    "ste": {
+      "name": "Liana-Seti"
+    },
+    "stf": {
+      "name": "Seta"
+    },
+    "stg": {
+      "name": "Trieng"
+    },
+    "sth": {
+      "name": "Shelta"
+    },
+    "sti": {
+      "name": "Bulo Stieng"
+    },
+    "stj": {
+      "name": "Matya Samo"
+    },
+    "stk": {
+      "name": "Arammba"
+    },
+    "stl": {
+      "name": "Stellingwerfs"
+    },
+    "stm": {
+      "name": "Setaman"
+    },
+    "stn": {
+      "name": "Owa"
+    },
+    "sto": {
+      "name": "Stoney"
+    },
+    "stp": {
+      "name": "Southeastern Tepehuan"
+    },
+    "stq": {
+      "name": "Saterfriesisch"
+    },
+    "str": {
+      "name": "Straits Salish"
+    },
+    "sts": {
+      "name": "Shumashti"
+    },
+    "stt": {
+      "name": "Budeh Stieng"
+    },
+    "stu": {
+      "name": "Samtao"
+    },
+    "stv": {
+      "name": "Silt'e"
+    },
+    "stw": {
+      "name": "Satawalese"
+    },
+    "sty": {
+      "name": "Siberian Tatar"
+    },
+    "sua": {
+      "name": "Sulka"
+    },
+    "sub": {
+      "name": "Suku"
+    },
+    "suc": {
+      "name": "Western Subanon"
+    },
+    "sue": {
+      "name": "Suena"
+    },
+    "sug": {
+      "name": "Suganga"
+    },
+    "sui": {
+      "name": "Suki"
+    },
+    "suj": {
+      "name": "Shubi"
+    },
+    "suk": {
+      "name": "Sukuma"
+    },
+    "sul": {
+      "name": "Surigaonon"
+    },
+    "sum": {
+      "name": "Sumo-Mayangna"
+    },
+    "suq": {
+      "name": "Suri"
+    },
+    "sur": {
+      "name": "Mwaghavul"
+    },
+    "sus": {
+      "name": "Susu"
+    },
+    "sut": {
+      "name": "Subtiaba"
+    },
+    "suv": {
+      "name": "Puroik"
+    },
+    "suw": {
+      "name": "Sumbwa"
+    },
+    "sux": {
+      "name": "Sumerian"
+    },
+    "suy": {
+      "name": "Suyá"
+    },
+    "suz": {
+      "name": "Sunwar"
+    },
+    "sva": {
+      "name": "Svan"
+    },
+    "svb": {
+      "name": "Ulau-Suain"
+    },
+    "svc": {
+      "name": "Vincentian Creole English"
+    },
+    "sve": {
+      "name": "Serili"
+    },
+    "svk": {
+      "name": "Slovakian Sign Language"
+    },
+    "svm": {
+      "name": "Slavomolisano"
+    },
+    "svr": {
+      "name": "Savara"
+    },
+    "svs": {
+      "name": "Savosavo"
+    },
+    "svx": {
+      "name": "Skalvian"
+    },
+    "swb": {
+      "name": "Maore Comorian"
+    },
+    "swc": {
+      "name": "Congo Swahili"
+    },
+    "swf": {
+      "name": "Sere"
+    },
+    "swg": {
+      "name": "Swabian"
+    },
+    "swh": {
+      "name": "Swahili (individual language)"
+    },
+    "swi": {
+      "name": "Sui"
+    },
+    "swj": {
+      "name": "Sira"
+    },
+    "swk": {
+      "name": "Malawi Sena"
+    },
+    "swl": {
+      "name": "Swedish Sign Language"
+    },
+    "swm": {
+      "name": "Samosa"
+    },
+    "swn": {
+      "name": "Sawknah"
+    },
+    "swo": {
+      "name": "Shanenawa"
+    },
+    "swp": {
+      "name": "Suau"
+    },
+    "swq": {
+      "name": "Sharwa"
+    },
+    "swr": {
+      "name": "Saweru"
+    },
+    "sws": {
+      "name": "Seluwasan"
+    },
+    "swt": {
+      "name": "Sawila"
+    },
+    "swu": {
+      "name": "Suwawa"
+    },
+    "swv": {
+      "name": "Shekhawati"
+    },
+    "sww": {
+      "name": "Sowa"
+    },
+    "swx": {
+      "name": "Suruahá"
+    },
+    "swy": {
+      "name": "Sarua"
+    },
+    "sxb": {
+      "name": "Suba"
+    },
+    "sxc": {
+      "name": "Sicanian"
+    },
+    "sxe": {
+      "name": "Sighu"
+    },
+    "sxg": {
+      "name": "Shuhi"
+    },
+    "sxk": {
+      "name": "Southern Kalapuya"
+    },
+    "sxl": {
+      "name": "Selian"
+    },
+    "sxm": {
+      "name": "Samre"
+    },
+    "sxn": {
+      "name": "Sangir"
+    },
+    "sxo": {
+      "name": "Sorothaptic"
+    },
+    "sxr": {
+      "name": "Saaroa"
+    },
+    "sxs": {
+      "name": "Sasaru"
+    },
+    "sxu": {
+      "name": "Upper Saxon"
+    },
+    "sxw": {
+      "name": "Saxwe Gbe"
+    },
+    "sya": {
+      "name": "Siang"
+    },
+    "syb": {
+      "name": "Central Subanen"
+    },
+    "syc": {
+      "name": "Classical Syriac"
+    },
+    "syd": {
+      "name": "Samoyedic languages"
+    },
+    "syi": {
+      "name": "Seki"
+    },
+    "syk": {
+      "name": "Sukur"
+    },
+    "syl": {
+      "name": "Sylheti"
+    },
+    "sym": {
+      "name": "Maya Samo"
+    },
+    "syn": {
+      "name": "Senaya"
+    },
+    "syo": {
+      "name": "Suoy"
+    },
+    "syr": {
+      "name": "Syriac"
+    },
+    "sys": {
+      "name": "Sinyar"
+    },
+    "syw": {
+      "name": "Kagate"
+    },
+    "syx": {
+      "name": "Samay"
+    },
+    "syy": {
+      "name": "Al-Sayyid Bedouin Sign Language"
+    },
+    "sza": {
+      "name": "Semelai"
+    },
+    "szb": {
+      "name": "Ngalum"
+    },
+    "szc": {
+      "name": "Semaq Beri"
+    },
+    "szd": {
+      "name": "Seru"
+    },
+    "sze": {
+      "name": "Seze"
+    },
+    "szg": {
+      "name": "Sengele"
+    },
+    "szl": {
+      "name": "Silesian"
+    },
+    "szn": {
+      "name": "Sula"
+    },
+    "szp": {
+      "name": "Suabo"
+    },
+    "szs": {
+      "name": "Solomon Islands Sign Language"
+    },
+    "szv": {
+      "name": "Isu (Fako Division)"
+    },
+    "szw": {
+      "name": "Sawai"
+    },
+    "taa": {
+      "name": "Lower Tanana"
+    },
+    "tab": {
+      "name": "Tabassaran"
+    },
+    "tac": {
+      "name": "Lowland Tarahumara"
+    },
+    "tad": {
+      "name": "Tause"
+    },
+    "tae": {
+      "name": "Tariana"
+    },
+    "taf": {
+      "name": "Tapirapé"
+    },
+    "tag": {
+      "name": "Tagoi"
+    },
+    "tai": {
+      "name": "Tai languages"
+    },
+    "taj": {
+      "name": "Eastern Tamang"
+    },
+    "tak": {
+      "name": "Tala"
+    },
+    "tal": {
+      "name": "Tal"
+    },
+    "tan": {
+      "name": "Tangale"
+    },
+    "tao": {
+      "name": "Yami"
+    },
+    "tap": {
+      "name": "Taabwa"
+    },
+    "taq": {
+      "name": "Tamasheq"
+    },
+    "tar": {
+      "name": "Central Tarahumara"
+    },
+    "tas": {
+      "name": "Tay Boi"
+    },
+    "tau": {
+      "name": "Upper Tanana"
+    },
+    "tav": {
+      "name": "Tatuyo"
+    },
+    "taw": {
+      "name": "Tai"
+    },
+    "tax": {
+      "name": "Tamki"
+    },
+    "tay": {
+      "name": "Atayal"
+    },
+    "taz": {
+      "name": "Tocho"
+    },
+    "tba": {
+      "name": "Aikanã"
+    },
+    "tbb": {
+      "name": "Tapeba"
+    },
+    "tbc": {
+      "name": "Takia"
+    },
+    "tbd": {
+      "name": "Kaki Ae"
+    },
+    "tbe": {
+      "name": "Tanimbili"
+    },
+    "tbf": {
+      "name": "Mandara"
+    },
+    "tbg": {
+      "name": "North Tairora"
+    },
+    "tbh": {
+      "name": "Thurawal"
+    },
+    "tbi": {
+      "name": "Gaam"
+    },
+    "tbj": {
+      "name": "Tiang"
+    },
+    "tbk": {
+      "name": "Calamian Tagbanwa"
+    },
+    "tbl": {
+      "name": "Tboli"
+    },
+    "tbm": {
+      "name": "Tagbu"
+    },
+    "tbn": {
+      "name": "Barro Negro Tunebo"
+    },
+    "tbo": {
+      "name": "Tawala"
+    },
+    "tbp": {
+      "name": "Taworta"
+    },
+    "tbq": {
+      "name": "Tibeto-Burman languages"
+    },
+    "tbr": {
+      "name": "Tumtum"
+    },
+    "tbs": {
+      "name": "Tanguat"
+    },
+    "tbt": {
+      "name": "Tembo (Kitembo)"
+    },
+    "tbu": {
+      "name": "Tubar"
+    },
+    "tbv": {
+      "name": "Tobo"
+    },
+    "tbw": {
+      "name": "Tagbanwa"
+    },
+    "tbx": {
+      "name": "Kapin"
+    },
+    "tby": {
+      "name": "Tabaru"
+    },
+    "tbz": {
+      "name": "Ditammari"
+    },
+    "tca": {
+      "name": "Ticuna"
+    },
+    "tcb": {
+      "name": "Tanacross"
+    },
+    "tcc": {
+      "name": "Datooga"
+    },
+    "tcd": {
+      "name": "Tafi"
+    },
+    "tce": {
+      "name": "Southern Tutchone"
+    },
+    "tcf": {
+      "name": "Malinaltepec Me'phaa"
+    },
+    "tcg": {
+      "name": "Tamagario"
+    },
+    "tch": {
+      "name": "Turks And Caicos Creole English"
+    },
+    "tci": {
+      "name": "Wára"
+    },
+    "tck": {
+      "name": "Tchitchege"
+    },
+    "tcl": {
+      "name": "Taman (Myanmar)"
+    },
+    "tcm": {
+      "name": "Tanahmerah"
+    },
+    "tcn": {
+      "name": "Tichurong"
+    },
+    "tco": {
+      "name": "Taungyo"
+    },
+    "tcp": {
+      "name": "Tawr Chin"
+    },
+    "tcq": {
+      "name": "Kaiy"
+    },
+    "tcs": {
+      "name": "Torres Strait Creole"
+    },
+    "tct": {
+      "name": "T'en"
+    },
+    "tcu": {
+      "name": "Southeastern Tarahumara"
+    },
+    "tcw": {
+      "name": "Tecpatlán Totonac"
+    },
+    "tcx": {
+      "name": "Toda"
+    },
+    "tcy": {
+      "name": "Tulu"
+    },
+    "tcz": {
+      "name": "Thado Chin"
+    },
+    "tda": {
+      "name": "Tagdal"
+    },
+    "tdb": {
+      "name": "Panchpargania"
+    },
+    "tdc": {
+      "name": "Emberá-Tadó"
+    },
+    "tdd": {
+      "name": "Tai Nüa"
+    },
+    "tde": {
+      "name": "Tiranige Diga Dogon"
+    },
+    "tdf": {
+      "name": "Talieng"
+    },
+    "tdg": {
+      "name": "Western Tamang"
+    },
+    "tdh": {
+      "name": "Thulung"
+    },
+    "tdi": {
+      "name": "Tomadino"
+    },
+    "tdj": {
+      "name": "Tajio"
+    },
+    "tdk": {
+      "name": "Tambas"
+    },
+    "tdl": {
+      "name": "Sur"
+    },
+    "tdm": {
+      "name": "Taruma"
+    },
+    "tdn": {
+      "name": "Tondano"
+    },
+    "tdo": {
+      "name": "Teme"
+    },
+    "tdq": {
+      "name": "Tita"
+    },
+    "tdr": {
+      "name": "Todrah"
+    },
+    "tds": {
+      "name": "Doutai"
+    },
+    "tdt": {
+      "name": "Tetun Dili"
+    },
+    "tdu": {
+      "name": "Tempasuk Dusun"
+    },
+    "tdv": {
+      "name": "Toro"
+    },
+    "tdx": {
+      "name": "Tandroy-Mahafaly Malagasy"
+    },
+    "tdy": {
+      "name": "Tadyawan"
+    },
+    "tea": {
+      "name": "Temiar"
+    },
+    "teb": {
+      "name": "Tetete"
+    },
+    "tec": {
+      "name": "Terik"
+    },
+    "ted": {
+      "name": "Tepo Krumen"
+    },
+    "tee": {
+      "name": "Huehuetla Tepehua"
+    },
+    "tef": {
+      "name": "Teressa"
+    },
+    "teg": {
+      "name": "Teke-Tege"
+    },
+    "teh": {
+      "name": "Tehuelche"
+    },
+    "tei": {
+      "name": "Torricelli"
+    },
+    "tek": {
+      "name": "Ibali Teke"
+    },
+    "tem": {
+      "name": "Timne"
+    },
+    "ten": {
+      "name": "Tama (Colombia)"
+    },
+    "teo": {
+      "name": "Teso"
+    },
+    "tep": {
+      "name": "Tepecano"
+    },
+    "teq": {
+      "name": "Temein"
+    },
+    "ter": {
+      "name": "Tereno"
+    },
+    "tes": {
+      "name": "Tengger"
+    },
+    "tet": {
+      "name": "Tetum"
+    },
+    "teu": {
+      "name": "Soo"
+    },
+    "tev": {
+      "name": "Teor"
+    },
+    "tew": {
+      "name": "Tewa (USA)"
+    },
+    "tex": {
+      "name": "Tennet"
+    },
+    "tey": {
+      "name": "Tulishi"
+    },
+    "tez": {
+      "name": "Tetserret"
+    },
+    "tfi": {
+      "name": "Tofin Gbe"
+    },
+    "tfn": {
+      "name": "Tanaina"
+    },
+    "tfo": {
+      "name": "Tefaro"
+    },
+    "tfr": {
+      "name": "Teribe"
+    },
+    "tft": {
+      "name": "Ternate"
+    },
+    "tga": {
+      "name": "Sagalla"
+    },
+    "tgb": {
+      "name": "Tobilung"
+    },
+    "tgc": {
+      "name": "Tigak"
+    },
+    "tgd": {
+      "name": "Ciwogai"
+    },
+    "tge": {
+      "name": "Eastern Gorkha Tamang"
+    },
+    "tgf": {
+      "name": "Chalikha"
+    },
+    "tgg": {
+      "name": "Tangga"
+    },
+    "tgh": {
+      "name": "Tobagonian Creole English"
+    },
+    "tgi": {
+      "name": "Lawunuia"
+    },
+    "tgj": {
+      "name": "Tagin"
+    },
+    "tgn": {
+      "name": "Tandaganon"
+    },
+    "tgo": {
+      "name": "Sudest"
+    },
+    "tgp": {
+      "name": "Tangoa"
+    },
+    "tgq": {
+      "name": "Tring"
+    },
+    "tgr": {
+      "name": "Tareng"
+    },
+    "tgs": {
+      "name": "Nume"
+    },
+    "tgt": {
+      "name": "Central Tagbanwa"
+    },
+    "tgu": {
+      "name": "Tanggu"
+    },
+    "tgv": {
+      "name": "Tingui-Boto"
+    },
+    "tgw": {
+      "name": "Tagwana Senoufo"
+    },
+    "tgx": {
+      "name": "Tagish"
+    },
+    "tgy": {
+      "name": "Togoyo"
+    },
+    "tgz": {
+      "name": "Tagalaka"
+    },
+    "thc": {
+      "name": "Tai Hang Tong"
+    },
+    "thd": {
+      "name": "Thayore"
+    },
+    "the": {
+      "name": "Chitwania Tharu"
+    },
+    "thf": {
+      "name": "Thangmi"
+    },
+    "thh": {
+      "name": "Northern Tarahumara"
+    },
+    "thi": {
+      "name": "Tai Long"
+    },
+    "thk": {
+      "name": "Tharaka"
+    },
+    "thl": {
+      "name": "Dangaura Tharu"
+    },
+    "thm": {
+      "name": "Aheu"
+    },
+    "thn": {
+      "name": "Thachanadan"
+    },
+    "thp": {
+      "name": "Thompson"
+    },
+    "thq": {
+      "name": "Kochila Tharu"
+    },
+    "thr": {
+      "name": "Rana Tharu"
+    },
+    "ths": {
+      "name": "Thakali"
+    },
+    "tht": {
+      "name": "Tahltan"
+    },
+    "thu": {
+      "name": "Thuri"
+    },
+    "thv": {
+      "name": "Tahaggart Tamahaq"
+    },
+    "thw": {
+      "name": "Thudam"
+    },
+    "thx": {
+      "name": "The"
+    },
+    "thy": {
+      "name": "Tha"
+    },
+    "thz": {
+      "name": "Tayart Tamajeq"
+    },
+    "tia": {
+      "name": "Tidikelt Tamazight"
+    },
+    "tic": {
+      "name": "Tira"
+    },
+    "tid": {
+      "name": "Tidong"
+    },
+    "tie": {
+      "name": "Tingal"
+    },
+    "tif": {
+      "name": "Tifal"
+    },
+    "tig": {
+      "name": "Tigre"
+    },
+    "tih": {
+      "name": "Timugon Murut"
+    },
+    "tii": {
+      "name": "Tiene"
+    },
+    "tij": {
+      "name": "Tilung"
+    },
+    "tik": {
+      "name": "Tikar"
+    },
+    "til": {
+      "name": "Tillamook"
+    },
+    "tim": {
+      "name": "Timbe"
+    },
+    "tin": {
+      "name": "Tindi"
+    },
+    "tio": {
+      "name": "Teop"
+    },
+    "tip": {
+      "name": "Trimuris"
+    },
+    "tiq": {
+      "name": "Tiéfo"
+    },
+    "tis": {
+      "name": "Masadiit Itneg"
+    },
+    "tit": {
+      "name": "Tinigua"
+    },
+    "tiu": {
+      "name": "Adasen"
+    },
+    "tiv": {
+      "name": "Tiv"
+    },
+    "tiw": {
+      "name": "Tiwi"
+    },
+    "tix": {
+      "name": "Southern Tiwa"
+    },
+    "tiy": {
+      "name": "Tiruray"
+    },
+    "tiz": {
+      "name": "Tai Hongjin"
+    },
+    "tja": {
+      "name": "Tajuasohn"
+    },
+    "tjg": {
+      "name": "Tunjung"
+    },
+    "tji": {
+      "name": "Northern Tujia"
+    },
+    "tjl": {
+      "name": "Tai Laing"
+    },
+    "tjm": {
+      "name": "Timucua"
+    },
+    "tjn": {
+      "name": "Tonjon"
+    },
+    "tjo": {
+      "name": "Temacine Tamazight"
+    },
+    "tjs": {
+      "name": "Southern Tujia"
+    },
+    "tju": {
+      "name": "Tjurruru"
+    },
+    "tjw": {
+      "name": "Djabwurrung"
+    },
+    "tka": {
+      "name": "Truká"
+    },
+    "tkb": {
+      "name": "Buksa"
+    },
+    "tkd": {
+      "name": "Tukudede"
+    },
+    "tke": {
+      "name": "Takwane"
+    },
+    "tkf": {
+      "name": "Tukumanféd"
+    },
+    "tkg": {
+      "name": "Tesaka Malagasy"
+    },
+    "tkk": {
+      "name": "Takpa"
+    },
+    "tkl": {
+      "name": "Tokelau"
+    },
+    "tkm": {
+      "name": "Takelma"
+    },
+    "tkn": {
+      "name": "Toku-No-Shima"
+    },
+    "tkp": {
+      "name": "Tikopia"
+    },
+    "tkq": {
+      "name": "Tee"
+    },
+    "tkr": {
+      "name": "Tsakhur"
+    },
+    "tks": {
+      "name": "Takestani"
+    },
+    "tkt": {
+      "name": "Kathoriya Tharu"
+    },
+    "tku": {
+      "name": "Upper Necaxa Totonac"
+    },
+    "tkv": {
+      "name": "Mur Pano"
+    },
+    "tkw": {
+      "name": "Teanu"
+    },
+    "tkx": {
+      "name": "Tangko"
+    },
+    "tkz": {
+      "name": "Takua"
+    },
+    "tla": {
+      "name": "Southwestern Tepehuan"
+    },
+    "tlb": {
+      "name": "Tobelo"
+    },
+    "tlc": {
+      "name": "Yecuatla Totonac"
+    },
+    "tld": {
+      "name": "Talaud"
+    },
+    "tlf": {
+      "name": "Telefol"
+    },
+    "tlg": {
+      "name": "Tofanma"
+    },
+    "tlh": {
+      "name": "Klingon"
+    },
+    "tli": {
+      "name": "Tlingit"
+    },
+    "tlj": {
+      "name": "Talinga-Bwisi"
+    },
+    "tlk": {
+      "name": "Taloki"
+    },
+    "tll": {
+      "name": "Tetela"
+    },
+    "tlm": {
+      "name": "Tolomako"
+    },
+    "tln": {
+      "name": "Talondo'"
+    },
+    "tlo": {
+      "name": "Talodi"
+    },
+    "tlp": {
+      "name": "Filomena Mata-Coahuitlán Totonac"
+    },
+    "tlq": {
+      "name": "Tai Loi"
+    },
+    "tlr": {
+      "name": "Talise"
+    },
+    "tls": {
+      "name": "Tambotalo"
+    },
+    "tlt": {
+      "name": "Sou Nama"
+    },
+    "tlu": {
+      "name": "Tulehu"
+    },
+    "tlv": {
+      "name": "Taliabu"
+    },
+    "tlw": {
+      "name": "South Wemale"
+    },
+    "tlx": {
+      "name": "Khehek"
+    },
+    "tly": {
+      "name": "Talysh"
+    },
+    "tma": {
+      "name": "Tama (Chad)"
+    },
+    "tmb": {
+      "name": "Katbol"
+    },
+    "tmc": {
+      "name": "Tumak"
+    },
+    "tmd": {
+      "name": "Haruai"
+    },
+    "tme": {
+      "name": "Tremembé"
+    },
+    "tmf": {
+      "name": "Toba-Maskoy"
+    },
+    "tmg": {
+      "name": "Ternateño"
+    },
+    "tmh": {
+      "name": "Tamashek"
+    },
+    "tmi": {
+      "name": "Tutuba"
+    },
+    "tmj": {
+      "name": "Samarokena"
+    },
+    "tmk": {
+      "name": "Northwestern Tamang"
+    },
+    "tml": {
+      "name": "Tamnim Citak"
+    },
+    "tmm": {
+      "name": "Tai Thanh"
+    },
+    "tmn": {
+      "name": "Taman (Indonesia)"
+    },
+    "tmo": {
+      "name": "Temoq"
+    },
+    "tmp": {
+      "name": "Tai Mène"
+    },
+    "tmq": {
+      "name": "Tumleo"
+    },
+    "tmr": {
+      "name": "Jewish Babylonian Aramaic (ca. 200-1200 CE)"
+    },
+    "tms": {
+      "name": "Tima"
+    },
+    "tmt": {
+      "name": "Tasmate"
+    },
+    "tmu": {
+      "name": "Iau"
+    },
+    "tmv": {
+      "name": "Tembo (Motembo)"
+    },
+    "tmw": {
+      "name": "Temuan"
+    },
+    "tmy": {
+      "name": "Tami"
+    },
+    "tmz": {
+      "name": "Tamanaku"
+    },
+    "tna": {
+      "name": "Tacana"
+    },
+    "tnb": {
+      "name": "Western Tunebo"
+    },
+    "tnc": {
+      "name": "Tanimuca-Retuarã"
+    },
+    "tnd": {
+      "name": "Angosturas Tunebo"
+    },
+    "tne": {
+      "name": "Tinoc Kallahan"
+    },
+    "tnf": {
+      "name": "Tangshewi"
+    },
+    "tng": {
+      "name": "Tobanga"
+    },
+    "tnh": {
+      "name": "Maiani"
+    },
+    "tni": {
+      "name": "Tandia"
+    },
+    "tnk": {
+      "name": "Kwamera"
+    },
+    "tnl": {
+      "name": "Lenakel"
+    },
+    "tnm": {
+      "name": "Tabla"
+    },
+    "tnn": {
+      "name": "North Tanna"
+    },
+    "tno": {
+      "name": "Toromono"
+    },
+    "tnp": {
+      "name": "Whitesands"
+    },
+    "tnq": {
+      "name": "Taino"
+    },
+    "tnr": {
+      "name": "Ménik"
+    },
+    "tns": {
+      "name": "Tenis"
+    },
+    "tnt": {
+      "name": "Tontemboan"
+    },
+    "tnu": {
+      "name": "Tay Khang"
+    },
+    "tnv": {
+      "name": "Tangchangya"
+    },
+    "tnw": {
+      "name": "Tonsawang"
+    },
+    "tnx": {
+      "name": "Tanema"
+    },
+    "tny": {
+      "name": "Tongwe"
+    },
+    "tnz": {
+      "name": "Ten'edn"
+    },
+    "tob": {
+      "name": "Toba"
+    },
+    "toc": {
+      "name": "Coyutla Totonac"
+    },
+    "tod": {
+      "name": "Toma"
+    },
+    "toe": {
+      "name": "Tomedes"
+    },
+    "tof": {
+      "name": "Gizrra"
+    },
+    "tog": {
+      "name": "Tonga (Nyasa)"
+    },
+    "toh": {
+      "name": "Gitonga"
+    },
+    "toi": {
+      "name": "Tonga (Zambia)"
+    },
+    "toj": {
+      "name": "Tojolabal"
+    },
+    "tol": {
+      "name": "Tolowa"
+    },
+    "tom": {
+      "name": "Tombulu"
+    },
+    "too": {
+      "name": "Xicotepec De Juárez Totonac"
+    },
+    "top": {
+      "name": "Papantla Totonac"
+    },
+    "toq": {
+      "name": "Toposa"
+    },
+    "tor": {
+      "name": "Togbo-Vara Banda"
+    },
+    "tos": {
+      "name": "Highland Totonac"
+    },
+    "tou": {
+      "name": "Tho"
+    },
+    "tov": {
+      "name": "Upper Taromi"
+    },
+    "tow": {
+      "name": "Jemez"
+    },
+    "tox": {
+      "name": "Tobian"
+    },
+    "toy": {
+      "name": "Topoiyo"
+    },
+    "toz": {
+      "name": "To"
+    },
+    "tpa": {
+      "name": "Taupota"
+    },
+    "tpc": {
+      "name": "Azoyú Me'phaa"
+    },
+    "tpe": {
+      "name": "Tippera"
+    },
+    "tpf": {
+      "name": "Tarpia"
+    },
+    "tpg": {
+      "name": "Kula"
+    },
+    "tpi": {
+      "name": "Tok Pisin"
+    },
+    "tpj": {
+      "name": "Tapieté"
+    },
+    "tpk": {
+      "name": "Tupinikin"
+    },
+    "tpl": {
+      "name": "Tlacoapa Me'phaa"
+    },
+    "tpm": {
+      "name": "Tampulma"
+    },
+    "tpn": {
+      "name": "Tupinambá"
+    },
+    "tpo": {
+      "name": "Tai Pao"
+    },
+    "tpp": {
+      "name": "Pisaflores Tepehua"
+    },
+    "tpq": {
+      "name": "Tukpa"
+    },
+    "tpr": {
+      "name": "Tuparí"
+    },
+    "tpt": {
+      "name": "Tlachichilco Tepehua"
+    },
+    "tpu": {
+      "name": "Tampuan"
+    },
+    "tpv": {
+      "name": "Tanapag"
+    },
+    "tpw": {
+      "name": "Tupí"
+    },
+    "tpx": {
+      "name": "Acatepec Me'phaa"
+    },
+    "tpy": {
+      "name": "Trumai"
+    },
+    "tpz": {
+      "name": "Tinputz"
+    },
+    "tqb": {
+      "name": "Tembé"
+    },
+    "tql": {
+      "name": "Lehali"
+    },
+    "tqm": {
+      "name": "Turumsa"
+    },
+    "tqn": {
+      "name": "Tenino"
+    },
+    "tqo": {
+      "name": "Toaripi"
+    },
+    "tqp": {
+      "name": "Tomoip"
+    },
+    "tqq": {
+      "name": "Tunni"
+    },
+    "tqr": {
+      "name": "Torona"
+    },
+    "tqt": {
+      "name": "Western Totonac"
+    },
+    "tqu": {
+      "name": "Touo"
+    },
+    "tqw": {
+      "name": "Tonkawa"
+    },
+    "tra": {
+      "name": "Tirahi"
+    },
+    "trb": {
+      "name": "Terebu"
+    },
+    "trc": {
+      "name": "Copala Triqui"
+    },
+    "trd": {
+      "name": "Turi"
+    },
+    "tre": {
+      "name": "East Tarangan"
+    },
+    "trf": {
+      "name": "Trinidadian Creole English"
+    },
+    "trg": {
+      "name": "Lishán Didán"
+    },
+    "trh": {
+      "name": "Turaka"
+    },
+    "tri": {
+      "name": "Trió"
+    },
+    "trj": {
+      "name": "Toram"
+    },
+    "trk": {
+      "name": "Turkic languages"
+    },
+    "trl": {
+      "name": "Traveller Scottish"
+    },
+    "trm": {
+      "name": "Tregami"
+    },
+    "trn": {
+      "name": "Trinitario"
+    },
+    "tro": {
+      "name": "Tarao Naga"
+    },
+    "trp": {
+      "name": "Kok Borok"
+    },
+    "trq": {
+      "name": "San Martín Itunyoso Triqui"
+    },
+    "trr": {
+      "name": "Taushiro"
+    },
+    "trs": {
+      "name": "Chicahuaxtla Triqui"
+    },
+    "trt": {
+      "name": "Tunggare"
+    },
+    "tru": {
+      "name": "Turoyo"
+    },
+    "trv": {
+      "name": "Taroko"
+    },
+    "trw": {
+      "name": "Torwali"
+    },
+    "trx": {
+      "name": "Tringgus-Sembaan Bidayuh"
+    },
+    "try": {
+      "name": "Turung"
+    },
+    "trz": {
+      "name": "Torá"
+    },
+    "tsa": {
+      "name": "Tsaangi"
+    },
+    "tsb": {
+      "name": "Tsamai"
+    },
+    "tsc": {
+      "name": "Tswa"
+    },
+    "tsd": {
+      "name": "Tsakonian"
+    },
+    "tse": {
+      "name": "Tunisian Sign Language"
+    },
+    "tsf": {
+      "name": "Southwestern Tamang"
+    },
+    "tsg": {
+      "name": "Tausug"
+    },
+    "tsh": {
+      "name": "Tsuvan"
+    },
+    "tsi": {
+      "name": "Tsimshian"
+    },
+    "tsj": {
+      "name": "Tshangla"
+    },
+    "tsk": {
+      "name": "Tseku"
+    },
+    "tsl": {
+      "name": "Ts'ün-Lao"
+    },
+    "tsm": {
+      "name": "Turkish Sign Language"
+    },
+    "tsp": {
+      "name": "Northern Toussian"
+    },
+    "tsq": {
+      "name": "Thai Sign Language"
+    },
+    "tsr": {
+      "name": "Akei"
+    },
+    "tss": {
+      "name": "Taiwan Sign Language"
+    },
+    "tst": {
+      "name": "Tondi Songway Kiini"
+    },
+    "tsu": {
+      "name": "Tsou"
+    },
+    "tsv": {
+      "name": "Tsogo"
+    },
+    "tsw": {
+      "name": "Tsishingini"
+    },
+    "tsx": {
+      "name": "Mubami"
+    },
+    "tsy": {
+      "name": "Tebul Sign Language"
+    },
+    "tsz": {
+      "name": "Purepecha"
+    },
+    "tta": {
+      "name": "Tutelo"
+    },
+    "ttb": {
+      "name": "Gaa"
+    },
+    "ttc": {
+      "name": "Tektiteko"
+    },
+    "ttd": {
+      "name": "Tauade"
+    },
+    "tte": {
+      "name": "Bwanabwana"
+    },
+    "ttf": {
+      "name": "Tuotomb"
+    },
+    "ttg": {
+      "name": "Tutong"
+    },
+    "tth": {
+      "name": "Upper Ta'oih"
+    },
+    "tti": {
+      "name": "Tobati"
+    },
+    "ttj": {
+      "name": "Tooro"
+    },
+    "ttk": {
+      "name": "Totoro"
+    },
+    "ttl": {
+      "name": "Totela"
+    },
+    "ttm": {
+      "name": "Northern Tutchone"
+    },
+    "ttn": {
+      "name": "Towei"
+    },
+    "tto": {
+      "name": "Lower Ta'oih"
+    },
+    "ttp": {
+      "name": "Tombelala"
+    },
+    "ttq": {
+      "name": "Tawallammat Tamajaq"
+    },
+    "ttr": {
+      "name": "Tera"
+    },
+    "tts": {
+      "name": "Northeastern Thai"
+    },
+    "ttt": {
+      "name": "Muslim Tat"
+    },
+    "ttu": {
+      "name": "Torau"
+    },
+    "ttv": {
+      "name": "Titan"
+    },
+    "ttw": {
+      "name": "Long Wat"
+    },
+    "tty": {
+      "name": "Sikaritai"
+    },
+    "ttz": {
+      "name": "Tsum"
+    },
+    "tua": {
+      "name": "Wiarumus"
+    },
+    "tub": {
+      "name": "Tübatulabal"
+    },
+    "tuc": {
+      "name": "Mutu"
+    },
+    "tud": {
+      "name": "Tuxá"
+    },
+    "tue": {
+      "name": "Tuyuca"
+    },
+    "tuf": {
+      "name": "Central Tunebo"
+    },
+    "tug": {
+      "name": "Tunia"
+    },
+    "tuh": {
+      "name": "Taulil"
+    },
+    "tui": {
+      "name": "Tupuri"
+    },
+    "tuj": {
+      "name": "Tugutil"
+    },
+    "tul": {
+      "name": "Tula"
+    },
+    "tum": {
+      "name": "Tumbuka"
+    },
+    "tun": {
+      "name": "Tunica"
+    },
+    "tuo": {
+      "name": "Tucano"
+    },
+    "tup": {
+      "name": "Tupi languages"
+    },
+    "tuq": {
+      "name": "Tedaga"
+    },
+    "tus": {
+      "name": "Tuscarora"
+    },
+    "tut": {
+      "name": "Altaic languages"
+    },
+    "tuu": {
+      "name": "Tututni"
+    },
+    "tuv": {
+      "name": "Turkana"
+    },
+    "tuw": {
+      "name": "Tungus languages"
+    },
+    "tux": {
+      "name": "Tuxináwa"
+    },
+    "tuy": {
+      "name": "Tugen"
+    },
+    "tuz": {
+      "name": "Turka"
+    },
+    "tva": {
+      "name": "Vaghua"
+    },
+    "tvd": {
+      "name": "Tsuvadi"
+    },
+    "tve": {
+      "name": "Te'un"
+    },
+    "tvk": {
+      "name": "Southeast Ambrym"
+    },
+    "tvl": {
+      "name": "Tuvalu"
+    },
+    "tvm": {
+      "name": "Tela-Masbuar"
+    },
+    "tvn": {
+      "name": "Tavoyan"
+    },
+    "tvo": {
+      "name": "Tidore"
+    },
+    "tvs": {
+      "name": "Taveta"
+    },
+    "tvt": {
+      "name": "Tutsa Naga"
+    },
+    "tvu": {
+      "name": "Tunen"
+    },
+    "tvw": {
+      "name": "Sedoa"
+    },
+    "tvy": {
+      "name": "Timor Pidgin"
+    },
+    "twa": {
+      "name": "Twana"
+    },
+    "twb": {
+      "name": "Western Tawbuid"
+    },
+    "twc": {
+      "name": "Teshenawa"
+    },
+    "twd": {
+      "name": "Twents"
+    },
+    "twe": {
+      "name": "Tewa (Indonesia)"
+    },
+    "twf": {
+      "name": "Northern Tiwa"
+    },
+    "twg": {
+      "name": "Tereweng"
+    },
+    "twh": {
+      "name": "Tai Dón"
+    },
+    "twl": {
+      "name": "Tawara"
+    },
+    "twm": {
+      "name": "Tawang Monpa"
+    },
+    "twn": {
+      "name": "Twendi"
+    },
+    "two": {
+      "name": "Tswapong"
+    },
+    "twp": {
+      "name": "Ere"
+    },
+    "twq": {
+      "name": "Tasawaq"
+    },
+    "twr": {
+      "name": "Southwestern Tarahumara"
+    },
+    "twt": {
+      "name": "Turiwára"
+    },
+    "twu": {
+      "name": "Termanu"
+    },
+    "tww": {
+      "name": "Tuwari"
+    },
+    "twx": {
+      "name": "Tewe"
+    },
+    "twy": {
+      "name": "Tawoyan"
+    },
+    "txa": {
+      "name": "Tombonuo"
+    },
+    "txb": {
+      "name": "Tokharian B"
+    },
+    "txc": {
+      "name": "Tsetsaut"
+    },
+    "txe": {
+      "name": "Totoli"
+    },
+    "txg": {
+      "name": "Tangut"
+    },
+    "txh": {
+      "name": "Thracian"
+    },
+    "txi": {
+      "name": "Ikpeng"
+    },
+    "txj": {
+      "name": "Tarjumo"
+    },
+    "txm": {
+      "name": "Tomini"
+    },
+    "txn": {
+      "name": "West Tarangan"
+    },
+    "txo": {
+      "name": "Toto"
+    },
+    "txq": {
+      "name": "Tii"
+    },
+    "txr": {
+      "name": "Tartessian"
+    },
+    "txs": {
+      "name": "Tonsea"
+    },
+    "txt": {
+      "name": "Citak"
+    },
+    "txu": {
+      "name": "Kayapó"
+    },
+    "txx": {
+      "name": "Tatana"
+    },
+    "txy": {
+      "name": "Tanosy Malagasy"
+    },
+    "tya": {
+      "name": "Tauya"
+    },
+    "tye": {
+      "name": "Kyanga"
+    },
+    "tyh": {
+      "name": "O'du"
+    },
+    "tyi": {
+      "name": "Teke-Tsaayi"
+    },
+    "tyj": {
+      "name": "Tai Do"
+    },
+    "tyl": {
+      "name": "Thu Lao"
+    },
+    "tyn": {
+      "name": "Kombai"
+    },
+    "typ": {
+      "name": "Thaypan"
+    },
+    "tyr": {
+      "name": "Tai Daeng"
+    },
+    "tys": {
+      "name": "Tày Sa Pa"
+    },
+    "tyt": {
+      "name": "Tày Tac"
+    },
+    "tyu": {
+      "name": "Kua"
+    },
+    "tyv": {
+      "name": "Tuvinian"
+    },
+    "tyx": {
+      "name": "Teke-Tyee"
+    },
+    "tyz": {
+      "name": "Tày"
+    },
+    "tza": {
+      "name": "Tanzanian Sign Language"
+    },
+    "tzh": {
+      "name": "Tzeltal"
+    },
+    "tzj": {
+      "name": "Tz'utujil"
+    },
+    "tzl": {
+      "name": "Talossan"
+    },
+    "tzm": {
+      "name": "Central Atlas Tamazight"
+    },
+    "tzn": {
+      "name": "Tugun"
+    },
+    "tzo": {
+      "name": "Tzotzil"
+    },
+    "tzx": {
+      "name": "Tabriak"
+    },
+    "uam": {
+      "name": "Uamué"
+    },
+    "uan": {
+      "name": "Kuan"
+    },
+    "uar": {
+      "name": "Tairuma"
+    },
+    "uba": {
+      "name": "Ubang"
+    },
+    "ubi": {
+      "name": "Ubi"
+    },
+    "ubl": {
+      "name": "Buhi'non Bikol"
+    },
+    "ubr": {
+      "name": "Ubir"
+    },
+    "ubu": {
+      "name": "Umbu-Ungu"
+    },
+    "uby": {
+      "name": "Ubykh"
+    },
+    "uda": {
+      "name": "Uda"
+    },
+    "ude": {
+      "name": "Udihe"
+    },
+    "udg": {
+      "name": "Muduga"
+    },
+    "udi": {
+      "name": "Udi"
+    },
+    "udj": {
+      "name": "Ujir"
+    },
+    "udl": {
+      "name": "Wuzlam"
+    },
+    "udm": {
+      "name": "Udmurt"
+    },
+    "udu": {
+      "name": "Uduk"
+    },
+    "ues": {
+      "name": "Kioko"
+    },
+    "ufi": {
+      "name": "Ufim"
+    },
+    "uga": {
+      "name": "Ugaritic"
+    },
+    "ugb": {
+      "name": "Kuku-Ugbanh"
+    },
+    "uge": {
+      "name": "Ughele"
+    },
+    "ugn": {
+      "name": "Ugandan Sign Language"
+    },
+    "ugo": {
+      "name": "Ugong"
+    },
+    "ugy": {
+      "name": "Uruguayan Sign Language"
+    },
+    "uha": {
+      "name": "Uhami"
+    },
+    "uhn": {
+      "name": "Damal"
+    },
+    "uis": {
+      "name": "Uisai"
+    },
+    "uiv": {
+      "name": "Iyive"
+    },
+    "uji": {
+      "name": "Tanjijili"
+    },
+    "uka": {
+      "name": "Kaburi"
+    },
+    "ukg": {
+      "name": "Ukuriguma"
+    },
+    "ukh": {
+      "name": "Ukhwejo"
+    },
+    "ukk": {
+      "name": "Muak Sa-aak"
+    },
+    "ukl": {
+      "name": "Ukrainian Sign Language"
+    },
+    "ukp": {
+      "name": "Ukpe-Bayobiri"
+    },
+    "ukq": {
+      "name": "Ukwa"
+    },
+    "uks": {
+      "name": "Urubú-Kaapor Sign Language"
+    },
+    "uku": {
+      "name": "Ukue"
+    },
+    "ukw": {
+      "name": "Ukwuani-Aboh-Ndoni"
+    },
+    "uky": {
+      "name": "Kuuk-Yak"
+    },
+    "ula": {
+      "name": "Fungwa"
+    },
+    "ulb": {
+      "name": "Ulukwumi"
+    },
+    "ulc": {
+      "name": "Ulch"
+    },
+    "ule": {
+      "name": "Lule"
+    },
+    "ulf": {
+      "name": "Usku"
+    },
+    "uli": {
+      "name": "Ulithian"
+    },
+    "ulk": {
+      "name": "Meriam"
+    },
+    "ull": {
+      "name": "Ullatan"
+    },
+    "ulm": {
+      "name": "Ulumanda'"
+    },
+    "uln": {
+      "name": "Unserdeutsch"
+    },
+    "ulu": {
+      "name": "Uma' Lung"
+    },
+    "ulw": {
+      "name": "Ulwa"
+    },
+    "uma": {
+      "name": "Umatilla"
+    },
+    "umb": {
+      "name": "Umbundu"
+    },
+    "umc": {
+      "name": "Marrucinian"
+    },
+    "umd": {
+      "name": "Umbindhamu"
+    },
+    "umg": {
+      "name": "Umbuygamu"
+    },
+    "umi": {
+      "name": "Ukit"
+    },
+    "umm": {
+      "name": "Umon"
+    },
+    "umn": {
+      "name": "Makyan Naga"
+    },
+    "umo": {
+      "name": "Umotína"
+    },
+    "ump": {
+      "name": "Umpila"
+    },
+    "umr": {
+      "name": "Umbugarla"
+    },
+    "ums": {
+      "name": "Pendau"
+    },
+    "umu": {
+      "name": "Munsee"
+    },
+    "una": {
+      "name": "North Watut"
+    },
+    "und": {
+      "name": "Undetermined"
+    },
+    "une": {
+      "name": "Uneme"
+    },
+    "ung": {
+      "name": "Ngarinyin"
+    },
+    "unk": {
+      "name": "Enawené-Nawé"
+    },
+    "unm": {
+      "name": "Unami"
+    },
+    "unn": {
+      "name": "Kurnai"
+    },
+    "unp": {
+      "name": "Worora"
+    },
+    "unr": {
+      "name": "Mundari"
+    },
+    "unu": {
+      "name": "Unubahe"
+    },
+    "unx": {
+      "name": "Munda"
+    },
+    "unz": {
+      "name": "Unde Kaili"
+    },
+    "uok": {
+      "name": "Uokha"
+    },
+    "upi": {
+      "name": "Umeda"
+    },
+    "upv": {
+      "name": "Uripiv-Wala-Rano-Atchin"
+    },
+    "ura": {
+      "name": "Urarina"
+    },
+    "urb": {
+      "name": "Urubú-Kaapor"
+    },
+    "urc": {
+      "name": "Urningangg"
+    },
+    "ure": {
+      "name": "Uru"
+    },
+    "urf": {
+      "name": "Uradhi"
+    },
+    "urg": {
+      "name": "Urigina"
+    },
+    "urh": {
+      "name": "Urhobo"
+    },
+    "uri": {
+      "name": "Urim"
+    },
+    "urj": {
+      "name": "Uralic languages"
+    },
+    "urk": {
+      "name": "Urak Lawoi'"
+    },
+    "url": {
+      "name": "Urali"
+    },
+    "urm": {
+      "name": "Urapmin"
+    },
+    "urn": {
+      "name": "Uruangnirin"
+    },
+    "uro": {
+      "name": "Ura (Papua New Guinea)"
+    },
+    "urp": {
+      "name": "Uru-Pa-In"
+    },
+    "urr": {
+      "name": "Lehalurup"
+    },
+    "urt": {
+      "name": "Urat"
+    },
+    "uru": {
+      "name": "Urumi"
+    },
+    "urv": {
+      "name": "Uruava"
+    },
+    "urw": {
+      "name": "Sop"
+    },
+    "urx": {
+      "name": "Urimo"
+    },
+    "ury": {
+      "name": "Orya"
+    },
+    "urz": {
+      "name": "Uru-Eu-Wau-Wau"
+    },
+    "usa": {
+      "name": "Usarufa"
+    },
+    "ush": {
+      "name": "Ushojo"
+    },
+    "usi": {
+      "name": "Usui"
+    },
+    "usk": {
+      "name": "Usaghade"
+    },
+    "usp": {
+      "name": "Uspanteco"
+    },
+    "usu": {
+      "name": "Uya"
+    },
+    "uta": {
+      "name": "Otank"
+    },
+    "ute": {
+      "name": "Ute-Southern Paiute"
+    },
+    "utp": {
+      "name": "Amba (Solomon Islands)"
+    },
+    "utr": {
+      "name": "Etulo"
+    },
+    "utu": {
+      "name": "Utu"
+    },
+    "uum": {
+      "name": "Urum"
+    },
+    "uun": {
+      "name": "Kulon-Pazeh"
+    },
+    "uur": {
+      "name": "Ura (Vanuatu)"
+    },
+    "uuu": {
+      "name": "U"
+    },
+    "uve": {
+      "name": "West Uvean"
+    },
+    "uvh": {
+      "name": "Uri"
+    },
+    "uvl": {
+      "name": "Lote"
+    },
+    "uwa": {
+      "name": "Kuku-Uwanh"
+    },
+    "uya": {
+      "name": "Doko-Uyanga"
+    },
+    "uzn": {
+      "name": "Northern Uzbek"
+    },
+    "uzs": {
+      "name": "Southern Uzbek"
+    },
+    "vaa": {
+      "name": "Vaagri Booli"
+    },
+    "vae": {
+      "name": "Vale"
+    },
+    "vaf": {
+      "name": "Vafsi"
+    },
+    "vag": {
+      "name": "Vagla"
+    },
+    "vah": {
+      "name": "Varhadi-Nagpuri"
+    },
+    "vai": {
+      "name": "Vai"
+    },
+    "vaj": {
+      "name": "Sekele"
+    },
+    "val": {
+      "name": "Vehes"
+    },
+    "vam": {
+      "name": "Vanimo"
+    },
+    "van": {
+      "name": "Valman"
+    },
+    "vao": {
+      "name": "Vao"
+    },
+    "vap": {
+      "name": "Vaiphei"
+    },
+    "var": {
+      "name": "Huarijio"
+    },
+    "vas": {
+      "name": "Vasavi"
+    },
+    "vau": {
+      "name": "Vanuma"
+    },
+    "vav": {
+      "name": "Varli"
+    },
+    "vay": {
+      "name": "Wayu"
+    },
+    "vbb": {
+      "name": "Southeast Babar"
+    },
+    "vbk": {
+      "name": "Southwestern Bontok"
+    },
+    "vec": {
+      "name": "Venetian"
+    },
+    "ved": {
+      "name": "Veddah"
+    },
+    "vel": {
+      "name": "Veluws"
+    },
+    "vem": {
+      "name": "Vemgo-Mabas"
+    },
+    "veo": {
+      "name": "Ventureño"
+    },
+    "vep": {
+      "name": "Veps"
+    },
+    "ver": {
+      "name": "Mom Jango"
+    },
+    "vgr": {
+      "name": "Vaghri"
+    },
+    "vgt": {
+      "name": "Vlaamse Gebarentaal"
+    },
+    "vic": {
+      "name": "Virgin Islands Creole English"
+    },
+    "vid": {
+      "name": "Vidunda"
+    },
+    "vif": {
+      "name": "Vili"
+    },
+    "vig": {
+      "name": "Viemo"
+    },
+    "vil": {
+      "name": "Vilela"
+    },
+    "vin": {
+      "name": "Vinza"
+    },
+    "vis": {
+      "name": "Vishavan"
+    },
+    "vit": {
+      "name": "Viti"
+    },
+    "viv": {
+      "name": "Iduna"
+    },
+    "vka": {
+      "name": "Kariyarra"
+    },
+    "vki": {
+      "name": "Ija-Zuba"
+    },
+    "vkj": {
+      "name": "Kujarge"
+    },
+    "vkk": {
+      "name": "Kaur"
+    },
+    "vkl": {
+      "name": "Kulisusu"
+    },
+    "vkm": {
+      "name": "Kamakan"
+    },
+    "vko": {
+      "name": "Kodeoha"
+    },
+    "vkp": {
+      "name": "Korlai Creole Portuguese"
+    },
+    "vkt": {
+      "name": "Tenggarong Kutai Malay"
+    },
+    "vku": {
+      "name": "Kurrama"
+    },
+    "vlp": {
+      "name": "Valpei"
+    },
+    "vls": {
+      "name": "Vlaams"
+    },
+    "vma": {
+      "name": "Martuyhunira"
+    },
+    "vmb": {
+      "name": "Barbaram"
+    },
+    "vmc": {
+      "name": "Juxtlahuaca Mixtec"
+    },
+    "vmd": {
+      "name": "Mudu Koraga"
+    },
+    "vme": {
+      "name": "East Masela"
+    },
+    "vmf": {
+      "name": "Mainfränkisch"
+    },
+    "vmg": {
+      "name": "Lungalunga"
+    },
+    "vmh": {
+      "name": "Maraghei"
+    },
+    "vmi": {
+      "name": "Miwa"
+    },
+    "vmj": {
+      "name": "Ixtayutla Mixtec"
+    },
+    "vmk": {
+      "name": "Makhuwa-Shirima"
+    },
+    "vml": {
+      "name": "Malgana"
+    },
+    "vmm": {
+      "name": "Mitlatongo Mixtec"
+    },
+    "vmp": {
+      "name": "Soyaltepec Mazatec"
+    },
+    "vmq": {
+      "name": "Soyaltepec Mixtec"
+    },
+    "vmr": {
+      "name": "Marenje"
+    },
+    "vms": {
+      "name": "Moksela"
+    },
+    "vmu": {
+      "name": "Muluridyi"
+    },
+    "vmv": {
+      "name": "Valley Maidu"
+    },
+    "vmw": {
+      "name": "Makhuwa"
+    },
+    "vmx": {
+      "name": "Tamazola Mixtec"
+    },
+    "vmy": {
+      "name": "Ayautla Mazatec"
+    },
+    "vmz": {
+      "name": "Mazatlán Mazatec"
+    },
+    "vnk": {
+      "name": "Vano"
+    },
+    "vnm": {
+      "name": "Vinmavis"
+    },
+    "vnp": {
+      "name": "Vunapu"
+    },
+    "vor": {
+      "name": "Voro"
+    },
+    "vot": {
+      "name": "Votic"
+    },
+    "vra": {
+      "name": "Vera'a"
+    },
+    "vro": {
+      "name": "Võro"
+    },
+    "vrs": {
+      "name": "Varisi"
+    },
+    "vrt": {
+      "name": "Burmbar"
+    },
+    "vsi": {
+      "name": "Moldova Sign Language"
+    },
+    "vsl": {
+      "name": "Venezuelan Sign Language"
+    },
+    "vsv": {
+      "name": "Valencian Sign Language"
+    },
+    "vto": {
+      "name": "Vitou"
+    },
+    "vum": {
+      "name": "Vumbu"
+    },
+    "vun": {
+      "name": "Vunjo"
+    },
+    "vut": {
+      "name": "Vute"
+    },
+    "vwa": {
+      "name": "Awa (China)"
+    },
+    "waa": {
+      "name": "Walla Walla"
+    },
+    "wab": {
+      "name": "Wab"
+    },
+    "wac": {
+      "name": "Wasco-Wishram"
+    },
+    "wad": {
+      "name": "Wandamen"
+    },
+    "wae": {
+      "name": "Walser"
+    },
+    "waf": {
+      "name": "Wakoná"
+    },
+    "wag": {
+      "name": "Wa'ema"
+    },
+    "wah": {
+      "name": "Watubela"
+    },
+    "wai": {
+      "name": "Wares"
+    },
+    "waj": {
+      "name": "Waffa"
+    },
+    "wak": {
+      "name": "Wakashan languages"
+    },
+    "wal": {
+      "name": "Wolaytta"
+    },
+    "wam": {
+      "name": "Wampanoag"
+    },
+    "wan": {
+      "name": "Wan"
+    },
+    "wao": {
+      "name": "Wappo"
+    },
+    "wap": {
+      "name": "Wapishana"
+    },
+    "waq": {
+      "name": "Wageman"
+    },
+    "war": {
+      "name": "Waray (Philippines)"
+    },
+    "was": {
+      "name": "Washo"
+    },
+    "wat": {
+      "name": "Kaninuwa"
+    },
+    "wau": {
+      "name": "Waurá"
+    },
+    "wav": {
+      "name": "Waka"
+    },
+    "waw": {
+      "name": "Waiwai"
+    },
+    "wax": {
+      "name": "Watam"
+    },
+    "way": {
+      "name": "Wayana"
+    },
+    "waz": {
+      "name": "Wampur"
+    },
+    "wba": {
+      "name": "Warao"
+    },
+    "wbb": {
+      "name": "Wabo"
+    },
+    "wbe": {
+      "name": "Waritai"
+    },
+    "wbf": {
+      "name": "Wara"
+    },
+    "wbh": {
+      "name": "Wanda"
+    },
+    "wbi": {
+      "name": "Vwanji"
+    },
+    "wbj": {
+      "name": "Alagwa"
+    },
+    "wbk": {
+      "name": "Waigali"
+    },
+    "wbl": {
+      "name": "Wakhi"
+    },
+    "wbm": {
+      "name": "Wa"
+    },
+    "wbp": {
+      "name": "Warlpiri"
+    },
+    "wbq": {
+      "name": "Waddar"
+    },
+    "wbr": {
+      "name": "Wagdi"
+    },
+    "wbs": {
+      "name": "West Bengal Sign Language"
+    },
+    "wbt": {
+      "name": "Wanman"
+    },
+    "wbv": {
+      "name": "Wajarri"
+    },
+    "wbw": {
+      "name": "Woi"
+    },
+    "wca": {
+      "name": "Yanomámi"
+    },
+    "wci": {
+      "name": "Waci Gbe"
+    },
+    "wdd": {
+      "name": "Wandji"
+    },
+    "wdg": {
+      "name": "Wadaginam"
+    },
+    "wdj": {
+      "name": "Wadjiginy"
+    },
+    "wdk": {
+      "name": "Wadikali"
+    },
+    "wdu": {
+      "name": "Wadjigu"
+    },
+    "wdy": {
+      "name": "Wadjabangayi"
+    },
+    "wea": {
+      "name": "Wewaw"
+    },
+    "wec": {
+      "name": "Wè Western"
+    },
+    "wed": {
+      "name": "Wedau"
+    },
+    "weg": {
+      "name": "Wergaia"
+    },
+    "weh": {
+      "name": "Weh"
+    },
+    "wei": {
+      "name": "Kiunum"
+    },
+    "wem": {
+      "name": "Weme Gbe"
+    },
+    "wen": {
+      "name": "Sorbian languages"
+    },
+    "weo": {
+      "name": "Wemale"
+    },
+    "wep": {
+      "name": "Westphalien"
+    },
+    "wer": {
+      "name": "Weri"
+    },
+    "wes": {
+      "name": "Cameroon Pidgin"
+    },
+    "wet": {
+      "name": "Perai"
+    },
+    "weu": {
+      "name": "Rawngtu Chin"
+    },
+    "wew": {
+      "name": "Wejewa"
+    },
+    "wfg": {
+      "name": "Yafi"
+    },
+    "wga": {
+      "name": "Wagaya"
+    },
+    "wgb": {
+      "name": "Wagawaga"
+    },
+    "wgg": {
+      "name": "Wangganguru"
+    },
+    "wgi": {
+      "name": "Wahgi"
+    },
+    "wgo": {
+      "name": "Waigeo"
+    },
+    "wgu": {
+      "name": "Wirangu"
+    },
+    "wgw": {
+      "name": "Wagawaga"
+    },
+    "wgy": {
+      "name": "Warrgamay"
+    },
+    "wha": {
+      "name": "Sou Upaa"
+    },
+    "whg": {
+      "name": "North Wahgi"
+    },
+    "whk": {
+      "name": "Wahau Kenyah"
+    },
+    "whu": {
+      "name": "Wahau Kayan"
+    },
+    "wib": {
+      "name": "Southern Toussian"
+    },
+    "wic": {
+      "name": "Wichita"
+    },
+    "wie": {
+      "name": "Wik-Epa"
+    },
+    "wif": {
+      "name": "Wik-Keyangan"
+    },
+    "wig": {
+      "name": "Wik-Ngathana"
+    },
+    "wih": {
+      "name": "Wik-Me'anha"
+    },
+    "wii": {
+      "name": "Minidien"
+    },
+    "wij": {
+      "name": "Wik-Iiyanh"
+    },
+    "wik": {
+      "name": "Wikalkan"
+    },
+    "wil": {
+      "name": "Wilawila"
+    },
+    "wim": {
+      "name": "Wik-Mungkan"
+    },
+    "win": {
+      "name": "Ho-Chunk"
+    },
+    "wir": {
+      "name": "Wiraféd"
+    },
+    "wit": {
+      "name": "Wintu"
+    },
+    "wiu": {
+      "name": "Wiru"
+    },
+    "wiv": {
+      "name": "Vitu"
+    },
+    "wiw": {
+      "name": "Wirangu"
+    },
+    "wiy": {
+      "name": "Wiyot"
+    },
+    "wja": {
+      "name": "Waja"
+    },
+    "wji": {
+      "name": "Warji"
+    },
+    "wka": {
+      "name": "Kw'adza"
+    },
+    "wkb": {
+      "name": "Kumbaran"
+    },
+    "wkd": {
+      "name": "Wakde"
+    },
+    "wkl": {
+      "name": "Kalanadi"
+    },
+    "wku": {
+      "name": "Kunduvadi"
+    },
+    "wkw": {
+      "name": "Wakawaka"
+    },
+    "wky": {
+      "name": "Wangkayutyuru"
+    },
+    "wla": {
+      "name": "Walio"
+    },
+    "wlc": {
+      "name": "Mwali Comorian"
+    },
+    "wle": {
+      "name": "Wolane"
+    },
+    "wlg": {
+      "name": "Kunbarlang"
+    },
+    "wli": {
+      "name": "Waioli"
+    },
+    "wlk": {
+      "name": "Wailaki"
+    },
+    "wll": {
+      "name": "Wali (Sudan)"
+    },
+    "wlm": {
+      "name": "Middle Welsh"
+    },
+    "wlo": {
+      "name": "Wolio"
+    },
+    "wlr": {
+      "name": "Wailapa"
+    },
+    "wls": {
+      "name": "Wallisian"
+    },
+    "wlu": {
+      "name": "Wuliwuli"
+    },
+    "wlv": {
+      "name": "Wichí Lhamtés Vejoz"
+    },
+    "wlw": {
+      "name": "Walak"
+    },
+    "wlx": {
+      "name": "Wali (Ghana)"
+    },
+    "wly": {
+      "name": "Waling"
+    },
+    "wma": {
+      "name": "Mawa (Nigeria)"
+    },
+    "wmb": {
+      "name": "Wambaya"
+    },
+    "wmc": {
+      "name": "Wamas"
+    },
+    "wmd": {
+      "name": "Mamaindé"
+    },
+    "wme": {
+      "name": "Wambule"
+    },
+    "wmh": {
+      "name": "Waima'a"
+    },
+    "wmi": {
+      "name": "Wamin"
+    },
+    "wmm": {
+      "name": "Maiwa (Indonesia)"
+    },
+    "wmn": {
+      "name": "Waamwang"
+    },
+    "wmo": {
+      "name": "Wom (Papua New Guinea)"
+    },
+    "wms": {
+      "name": "Wambon"
+    },
+    "wmt": {
+      "name": "Walmajarri"
+    },
+    "wmw": {
+      "name": "Mwani"
+    },
+    "wmx": {
+      "name": "Womo"
+    },
+    "wnb": {
+      "name": "Wanambre"
+    },
+    "wnc": {
+      "name": "Wantoat"
+    },
+    "wnd": {
+      "name": "Wandarang"
+    },
+    "wne": {
+      "name": "Waneci"
+    },
+    "wng": {
+      "name": "Wanggom"
+    },
+    "wni": {
+      "name": "Ndzwani Comorian"
+    },
+    "wnk": {
+      "name": "Wanukaka"
+    },
+    "wnm": {
+      "name": "Wanggamala"
+    },
+    "wnn": {
+      "name": "Wunumara"
+    },
+    "wno": {
+      "name": "Wano"
+    },
+    "wnp": {
+      "name": "Wanap"
+    },
+    "wnu": {
+      "name": "Usan"
+    },
+    "wnw": {
+      "name": "Wintu"
+    },
+    "wny": {
+      "name": "Wanyi"
+    },
+    "woa": {
+      "name": "Tyaraity"
+    },
+    "wob": {
+      "name": "Wè Northern"
+    },
+    "woc": {
+      "name": "Wogeo"
+    },
+    "wod": {
+      "name": "Wolani"
+    },
+    "woe": {
+      "name": "Woleaian"
+    },
+    "wof": {
+      "name": "Gambian Wolof"
+    },
+    "wog": {
+      "name": "Wogamusin"
+    },
+    "woi": {
+      "name": "Kamang"
+    },
+    "wok": {
+      "name": "Longto"
+    },
+    "wom": {
+      "name": "Wom (Nigeria)"
+    },
+    "won": {
+      "name": "Wongo"
+    },
+    "woo": {
+      "name": "Manombai"
+    },
+    "wor": {
+      "name": "Woria"
+    },
+    "wos": {
+      "name": "Hanga Hundi"
+    },
+    "wow": {
+      "name": "Wawonii"
+    },
+    "woy": {
+      "name": "Weyto"
+    },
+    "wpc": {
+      "name": "Maco"
+    },
+    "wra": {
+      "name": "Warapu"
+    },
+    "wrb": {
+      "name": "Warluwara"
+    },
+    "wrd": {
+      "name": "Warduji"
+    },
+    "wrg": {
+      "name": "Warungu"
+    },
+    "wrh": {
+      "name": "Wiradhuri"
+    },
+    "wri": {
+      "name": "Wariyangga"
+    },
+    "wrk": {
+      "name": "Garrwa"
+    },
+    "wrl": {
+      "name": "Warlmanpa"
+    },
+    "wrm": {
+      "name": "Warumungu"
+    },
+    "wrn": {
+      "name": "Warnang"
+    },
+    "wro": {
+      "name": "Worrorra"
+    },
+    "wrp": {
+      "name": "Waropen"
+    },
+    "wrr": {
+      "name": "Wardaman"
+    },
+    "wrs": {
+      "name": "Waris"
+    },
+    "wru": {
+      "name": "Waru"
+    },
+    "wrv": {
+      "name": "Waruna"
+    },
+    "wrw": {
+      "name": "Gugu Warra"
+    },
+    "wrx": {
+      "name": "Wae Rana"
+    },
+    "wry": {
+      "name": "Merwari"
+    },
+    "wrz": {
+      "name": "Waray (Australia)"
+    },
+    "wsa": {
+      "name": "Warembori"
+    },
+    "wsg": {
+      "name": "Adilabad Gondi"
+    },
+    "wsi": {
+      "name": "Wusi"
+    },
+    "wsk": {
+      "name": "Waskia"
+    },
+    "wsr": {
+      "name": "Owenia"
+    },
+    "wss": {
+      "name": "Wasa"
+    },
+    "wsu": {
+      "name": "Wasu"
+    },
+    "wsv": {
+      "name": "Wotapuri-Katarqalai"
+    },
+    "wtf": {
+      "name": "Watiwa"
+    },
+    "wth": {
+      "name": "Wathawurrung"
+    },
+    "wti": {
+      "name": "Berta"
+    },
+    "wtk": {
+      "name": "Watakataui"
+    },
+    "wtm": {
+      "name": "Mewati"
+    },
+    "wtw": {
+      "name": "Wotu"
+    },
+    "wua": {
+      "name": "Wikngenchera"
+    },
+    "wub": {
+      "name": "Wunambal"
+    },
+    "wud": {
+      "name": "Wudu"
+    },
+    "wuh": {
+      "name": "Wutunhua"
+    },
+    "wul": {
+      "name": "Silimo"
+    },
+    "wum": {
+      "name": "Wumbvu"
+    },
+    "wun": {
+      "name": "Bungu"
+    },
+    "wur": {
+      "name": "Wurrugu"
+    },
+    "wut": {
+      "name": "Wutung"
+    },
+    "wuu": {
+      "name": "Wu Chinese"
+    },
+    "wuv": {
+      "name": "Wuvulu-Aua"
+    },
+    "wux": {
+      "name": "Wulna"
+    },
+    "wuy": {
+      "name": "Wauyai"
+    },
+    "wwa": {
+      "name": "Waama"
+    },
+    "wwb": {
+      "name": "Wakabunga"
+    },
+    "wwo": {
+      "name": "Wetamut"
+    },
+    "wwr": {
+      "name": "Warrwa"
+    },
+    "www": {
+      "name": "Wawa"
+    },
+    "wxa": {
+      "name": "Waxianghua"
+    },
+    "wxw": {
+      "name": "Wardandi"
+    },
+    "wya": {
+      "name": "Wyandot"
+    },
+    "wyb": {
+      "name": "Wangaaybuwan-Ngiyambaa"
+    },
+    "wyi": {
+      "name": "Woiwurrung"
+    },
+    "wym": {
+      "name": "Wymysorys"
+    },
+    "wyr": {
+      "name": "Wayoró"
+    },
+    "wyy": {
+      "name": "Western Fijian"
+    },
+    "xaa": {
+      "name": "Andalusian Arabic"
+    },
+    "xab": {
+      "name": "Sambe"
+    },
+    "xac": {
+      "name": "Kachari"
+    },
+    "xad": {
+      "name": "Adai"
+    },
+    "xae": {
+      "name": "Aequian"
+    },
+    "xag": {
+      "name": "Aghwan"
+    },
+    "xai": {
+      "name": "Kaimbé"
+    },
+    "xaj": {
+      "name": "Ararandewára"
+    },
+    "xak": {
+      "name": "Máku"
+    },
+    "xal": {
+      "name": "Kalmyk"
+    },
+    "xam": {
+      "name": "/Xam"
+    },
+    "xan": {
+      "name": "Xamtanga"
+    },
+    "xao": {
+      "name": "Khao"
+    },
+    "xap": {
+      "name": "Apalachee"
+    },
+    "xaq": {
+      "name": "Aquitanian"
+    },
+    "xar": {
+      "name": "Karami"
+    },
+    "xas": {
+      "name": "Kamas"
+    },
+    "xat": {
+      "name": "Katawixi"
+    },
+    "xau": {
+      "name": "Kauwera"
+    },
+    "xav": {
+      "name": "Xavánte"
+    },
+    "xaw": {
+      "name": "Kawaiisu"
+    },
+    "xay": {
+      "name": "Kayan Mahakam"
+    },
+    "xba": {
+      "name": "Kamba (Brazil)"
+    },
+    "xbb": {
+      "name": "Lower Burdekin"
+    },
+    "xbc": {
+      "name": "Bactrian"
+    },
+    "xbd": {
+      "name": "Bindal"
+    },
+    "xbe": {
+      "name": "Bigambal"
+    },
+    "xbg": {
+      "name": "Bunganditj"
+    },
+    "xbi": {
+      "name": "Kombio"
+    },
+    "xbj": {
+      "name": "Birrpayi"
+    },
+    "xbm": {
+      "name": "Middle Breton"
+    },
+    "xbn": {
+      "name": "Kenaboi"
+    },
+    "xbo": {
+      "name": "Bolgarian"
+    },
+    "xbp": {
+      "name": "Bibbulman"
+    },
+    "xbr": {
+      "name": "Kambera"
+    },
+    "xbw": {
+      "name": "Kambiwá"
+    },
+    "xbx": {
+      "name": "Kabixí"
+    },
+    "xby": {
+      "name": "Batyala"
+    },
+    "xcb": {
+      "name": "Cumbric"
+    },
+    "xcc": {
+      "name": "Camunic"
+    },
+    "xce": {
+      "name": "Celtiberian"
+    },
+    "xcg": {
+      "name": "Cisalpine Gaulish"
+    },
+    "xch": {
+      "name": "Chemakum"
+    },
+    "xcl": {
+      "name": "Classical Armenian"
+    },
+    "xcm": {
+      "name": "Comecrudo"
+    },
+    "xcn": {
+      "name": "Cotoname"
+    },
+    "xco": {
+      "name": "Chorasmian"
+    },
+    "xcr": {
+      "name": "Carian"
+    },
+    "xct": {
+      "name": "Classical Tibetan"
+    },
+    "xcu": {
+      "name": "Curonian"
+    },
+    "xcv": {
+      "name": "Chuvantsy"
+    },
+    "xcw": {
+      "name": "Coahuilteco"
+    },
+    "xcy": {
+      "name": "Cayuse"
+    },
+    "xda": {
+      "name": "Darkinyung"
+    },
+    "xdc": {
+      "name": "Dacian"
+    },
+    "xdk": {
+      "name": "Dharuk"
+    },
+    "xdm": {
+      "name": "Edomite"
+    },
+    "xdo": {
+      "name": "Kwandu"
+    },
+    "xdy": {
+      "name": "Malayic Dayak"
+    },
+    "xeb": {
+      "name": "Eblan"
+    },
+    "xed": {
+      "name": "Hdi"
+    },
+    "xeg": {
+      "name": "//Xegwi"
+    },
+    "xel": {
+      "name": "Kelo"
+    },
+    "xem": {
+      "name": "Kembayan"
+    },
+    "xep": {
+      "name": "Epi-Olmec"
+    },
+    "xer": {
+      "name": "Xerénte"
+    },
+    "xes": {
+      "name": "Kesawai"
+    },
+    "xet": {
+      "name": "Xetá"
+    },
+    "xeu": {
+      "name": "Keoru-Ahia"
+    },
+    "xfa": {
+      "name": "Faliscan"
+    },
+    "xga": {
+      "name": "Galatian"
+    },
+    "xgb": {
+      "name": "Gbin"
+    },
+    "xgd": {
+      "name": "Gudang"
+    },
+    "xgf": {
+      "name": "Gabrielino-Fernandeño"
+    },
+    "xgg": {
+      "name": "Goreng"
+    },
+    "xgi": {
+      "name": "Garingbal"
+    },
+    "xgl": {
+      "name": "Galindan"
+    },
+    "xgm": {
+      "name": "Dharumbal"
+    },
+    "xgn": {
+      "name": "Mongolian languages"
+    },
+    "xgr": {
+      "name": "Garza"
+    },
+    "xgu": {
+      "name": "Unggumi"
+    },
+    "xgw": {
+      "name": "Guwa"
+    },
+    "xha": {
+      "name": "Harami"
+    },
+    "xhc": {
+      "name": "Hunnic"
+    },
+    "xhd": {
+      "name": "Hadrami"
+    },
+    "xhe": {
+      "name": "Khetrani"
+    },
+    "xhr": {
+      "name": "Hernican"
+    },
+    "xht": {
+      "name": "Hattic"
+    },
+    "xhu": {
+      "name": "Hurrian"
+    },
+    "xhv": {
+      "name": "Khua"
+    },
+    "xia": {
+      "name": "Xiandao"
+    },
+    "xib": {
+      "name": "Iberian"
+    },
+    "xii": {
+      "name": "Xiri"
+    },
+    "xil": {
+      "name": "Illyrian"
+    },
+    "xin": {
+      "name": "Xinca"
+    },
+    "xip": {
+      "name": "Xipináwa"
+    },
+    "xir": {
+      "name": "Xiriâna"
+    },
+    "xis": {
+      "name": "Kisan"
+    },
+    "xiv": {
+      "name": "Indus Valley Language"
+    },
+    "xiy": {
+      "name": "Xipaya"
+    },
+    "xjb": {
+      "name": "Minjungbal"
+    },
+    "xjt": {
+      "name": "Jaitmatang"
+    },
+    "xka": {
+      "name": "Kalkoti"
+    },
+    "xkb": {
+      "name": "Northern Nago"
+    },
+    "xkc": {
+      "name": "Kho'ini"
+    },
+    "xkd": {
+      "name": "Mendalam Kayan"
+    },
+    "xke": {
+      "name": "Kereho"
+    },
+    "xkf": {
+      "name": "Khengkha"
+    },
+    "xkg": {
+      "name": "Kagoro"
+    },
+    "xkh": {
+      "name": "Karahawyana"
+    },
+    "xki": {
+      "name": "Kenyan Sign Language"
+    },
+    "xkj": {
+      "name": "Kajali"
+    },
+    "xkk": {
+      "name": "Kaco'"
+    },
+    "xkl": {
+      "name": "Mainstream Kenyah"
+    },
+    "xkn": {
+      "name": "Kayan River Kayan"
+    },
+    "xko": {
+      "name": "Kiorr"
+    },
+    "xkp": {
+      "name": "Kabatei"
+    },
+    "xkq": {
+      "name": "Koroni"
+    },
+    "xkr": {
+      "name": "Xakriabá"
+    },
+    "xks": {
+      "name": "Kumbewaha"
+    },
+    "xkt": {
+      "name": "Kantosi"
+    },
+    "xku": {
+      "name": "Kaamba"
+    },
+    "xkv": {
+      "name": "Kgalagadi"
+    },
+    "xkw": {
+      "name": "Kembra"
+    },
+    "xkx": {
+      "name": "Karore"
+    },
+    "xky": {
+      "name": "Uma' Lasan"
+    },
+    "xkz": {
+      "name": "Kurtokha"
+    },
+    "xla": {
+      "name": "Kamula"
+    },
+    "xlb": {
+      "name": "Loup B"
+    },
+    "xlc": {
+      "name": "Lycian"
+    },
+    "xld": {
+      "name": "Lydian"
+    },
+    "xle": {
+      "name": "Lemnian"
+    },
+    "xlg": {
+      "name": "Ligurian (Ancient)"
+    },
+    "xli": {
+      "name": "Liburnian"
+    },
+    "xln": {
+      "name": "Alanic"
+    },
+    "xlo": {
+      "name": "Loup A"
+    },
+    "xlp": {
+      "name": "Lepontic"
+    },
+    "xls": {
+      "name": "Lusitanian"
+    },
+    "xlu": {
+      "name": "Cuneiform Luwian"
+    },
+    "xly": {
+      "name": "Elymian"
+    },
+    "xma": {
+      "name": "Mushungulu"
+    },
+    "xmb": {
+      "name": "Mbonga"
+    },
+    "xmc": {
+      "name": "Makhuwa-Marrevone"
+    },
+    "xmd": {
+      "name": "Mbudum"
+    },
+    "xme": {
+      "name": "Median"
+    },
+    "xmf": {
+      "name": "Mingrelian"
+    },
+    "xmg": {
+      "name": "Mengaka"
+    },
+    "xmh": {
+      "name": "Kuku-Muminh"
+    },
+    "xmj": {
+      "name": "Majera"
+    },
+    "xmk": {
+      "name": "Ancient Macedonian"
+    },
+    "xml": {
+      "name": "Malaysian Sign Language"
+    },
+    "xmm": {
+      "name": "Manado Malay"
+    },
+    "xmn": {
+      "name": "Manichaean Middle Persian"
+    },
+    "xmo": {
+      "name": "Morerebi"
+    },
+    "xmp": {
+      "name": "Kuku-Mu'inh"
+    },
+    "xmq": {
+      "name": "Kuku-Mangk"
+    },
+    "xmr": {
+      "name": "Meroitic"
+    },
+    "xms": {
+      "name": "Moroccan Sign Language"
+    },
+    "xmt": {
+      "name": "Matbat"
+    },
+    "xmu": {
+      "name": "Kamu"
+    },
+    "xmv": {
+      "name": "Antankarana Malagasy"
+    },
+    "xmw": {
+      "name": "Tsimihety Malagasy"
+    },
+    "xmx": {
+      "name": "Maden"
+    },
+    "xmy": {
+      "name": "Mayaguduna"
+    },
+    "xmz": {
+      "name": "Mori Bawah"
+    },
+    "xna": {
+      "name": "Ancient North Arabian"
+    },
+    "xnb": {
+      "name": "Kanakanabu"
+    },
+    "xnd": {
+      "name": "Na-Dene languages"
+    },
+    "xng": {
+      "name": "Middle Mongolian"
+    },
+    "xnh": {
+      "name": "Kuanhua"
+    },
+    "xni": {
+      "name": "Ngarigu"
+    },
+    "xnk": {
+      "name": "Nganakarti"
+    },
+    "xnn": {
+      "name": "Northern Kankanay"
+    },
+    "xno": {
+      "name": "Anglo-Norman"
+    },
+    "xnr": {
+      "name": "Kangri"
+    },
+    "xns": {
+      "name": "Kanashi"
+    },
+    "xnt": {
+      "name": "Narragansett"
+    },
+    "xnu": {
+      "name": "Nukunul"
+    },
+    "xny": {
+      "name": "Nyiyaparli"
+    },
+    "xnz": {
+      "name": "Kenzi"
+    },
+    "xoc": {
+      "name": "O'chi'chi'"
+    },
+    "xod": {
+      "name": "Kokoda"
+    },
+    "xog": {
+      "name": "Soga"
+    },
+    "xoi": {
+      "name": "Kominimung"
+    },
+    "xok": {
+      "name": "Xokleng"
+    },
+    "xom": {
+      "name": "Komo (Sudan)"
+    },
+    "xon": {
+      "name": "Konkomba"
+    },
+    "xoo": {
+      "name": "Xukurú"
+    },
+    "xop": {
+      "name": "Kopar"
+    },
+    "xor": {
+      "name": "Korubo"
+    },
+    "xow": {
+      "name": "Kowaki"
+    },
+    "xpa": {
+      "name": "Pirriya"
+    },
+    "xpc": {
+      "name": "Pecheneg"
+    },
+    "xpe": {
+      "name": "Liberia Kpelle"
+    },
+    "xpg": {
+      "name": "Phrygian"
+    },
+    "xpi": {
+      "name": "Pictish"
+    },
+    "xpj": {
+      "name": "Mpalitjanh"
+    },
+    "xpk": {
+      "name": "Kulina Pano"
+    },
+    "xpm": {
+      "name": "Pumpokol"
+    },
+    "xpn": {
+      "name": "Kapinawá"
+    },
+    "xpo": {
+      "name": "Pochutec"
+    },
+    "xpp": {
+      "name": "Puyo-Paekche"
+    },
+    "xpq": {
+      "name": "Mohegan-Pequot"
+    },
+    "xpr": {
+      "name": "Parthian"
+    },
+    "xps": {
+      "name": "Pisidian"
+    },
+    "xpt": {
+      "name": "Punthamara"
+    },
+    "xpu": {
+      "name": "Punic"
+    },
+    "xpy": {
+      "name": "Puyo"
+    },
+    "xqa": {
+      "name": "Karakhanid"
+    },
+    "xqt": {
+      "name": "Qatabanian"
+    },
+    "xra": {
+      "name": "Krahô"
+    },
+    "xrb": {
+      "name": "Eastern Karaboro"
+    },
+    "xrd": {
+      "name": "Gundungurra"
+    },
+    "xre": {
+      "name": "Kreye"
+    },
+    "xrg": {
+      "name": "Minang"
+    },
+    "xri": {
+      "name": "Krikati-Timbira"
+    },
+    "xrm": {
+      "name": "Armazic"
+    },
+    "xrn": {
+      "name": "Arin"
+    },
+    "xrq": {
+      "name": "Karranga"
+    },
+    "xrr": {
+      "name": "Raetic"
+    },
+    "xrt": {
+      "name": "Aranama-Tamique"
+    },
+    "xru": {
+      "name": "Marriammu"
+    },
+    "xrw": {
+      "name": "Karawa"
+    },
+    "xsa": {
+      "name": "Sabaean"
+    },
+    "xsb": {
+      "name": "Sambal"
+    },
+    "xsc": {
+      "name": "Scythian"
+    },
+    "xsd": {
+      "name": "Sidetic"
+    },
+    "xse": {
+      "name": "Sempan"
+    },
+    "xsh": {
+      "name": "Shamang"
+    },
+    "xsi": {
+      "name": "Sio"
+    },
+    "xsj": {
+      "name": "Subi"
+    },
+    "xsl": {
+      "name": "South Slavey"
+    },
+    "xsm": {
+      "name": "Kasem"
+    },
+    "xsn": {
+      "name": "Sanga (Nigeria)"
+    },
+    "xso": {
+      "name": "Solano"
+    },
+    "xsp": {
+      "name": "Silopi"
+    },
+    "xsq": {
+      "name": "Makhuwa-Saka"
+    },
+    "xsr": {
+      "name": "Sherpa"
+    },
+    "xss": {
+      "name": "Assan"
+    },
+    "xsu": {
+      "name": "Sanumá"
+    },
+    "xsv": {
+      "name": "Sudovian"
+    },
+    "xsy": {
+      "name": "Saisiyat"
+    },
+    "xta": {
+      "name": "Alcozauca Mixtec"
+    },
+    "xtb": {
+      "name": "Chazumba Mixtec"
+    },
+    "xtc": {
+      "name": "Katcha-Kadugli-Miri"
+    },
+    "xtd": {
+      "name": "Diuxi-Tilantongo Mixtec"
+    },
+    "xte": {
+      "name": "Ketengban"
+    },
+    "xtg": {
+      "name": "Transalpine Gaulish"
+    },
+    "xth": {
+      "name": "Yitha Yitha"
+    },
+    "xti": {
+      "name": "Sinicahua Mixtec"
+    },
+    "xtj": {
+      "name": "San Juan Teita Mixtec"
+    },
+    "xtl": {
+      "name": "Tijaltepec Mixtec"
+    },
+    "xtm": {
+      "name": "Magdalena Peñasco Mixtec"
+    },
+    "xtn": {
+      "name": "Northern Tlaxiaco Mixtec"
+    },
+    "xto": {
+      "name": "Tokharian A"
+    },
+    "xtp": {
+      "name": "San Miguel Piedras Mixtec"
+    },
+    "xtq": {
+      "name": "Tumshuqese"
+    },
+    "xtr": {
+      "name": "Early Tripuri"
+    },
+    "xts": {
+      "name": "Sindihui Mixtec"
+    },
+    "xtt": {
+      "name": "Tacahua Mixtec"
+    },
+    "xtu": {
+      "name": "Cuyamecalco Mixtec"
+    },
+    "xtv": {
+      "name": "Thawa"
+    },
+    "xtw": {
+      "name": "Tawandê"
+    },
+    "xty": {
+      "name": "Yoloxochitl Mixtec"
+    },
+    "xtz": {
+      "name": "Tasmanian"
+    },
+    "xua": {
+      "name": "Alu Kurumba"
+    },
+    "xub": {
+      "name": "Betta Kurumba"
+    },
+    "xud": {
+      "name": "Umiida"
+    },
+    "xug": {
+      "name": "Kunigami"
+    },
+    "xuj": {
+      "name": "Jennu Kurumba"
+    },
+    "xul": {
+      "name": "Ngunawal"
+    },
+    "xum": {
+      "name": "Umbrian"
+    },
+    "xun": {
+      "name": "Unggaranggu"
+    },
+    "xuo": {
+      "name": "Kuo"
+    },
+    "xup": {
+      "name": "Upper Umpqua"
+    },
+    "xur": {
+      "name": "Urartian"
+    },
+    "xut": {
+      "name": "Kuthant"
+    },
+    "xuu": {
+      "name": "Kxoe"
+    },
+    "xve": {
+      "name": "Venetic"
+    },
+    "xvi": {
+      "name": "Kamviri"
+    },
+    "xvn": {
+      "name": "Vandalic"
+    },
+    "xvo": {
+      "name": "Volscian"
+    },
+    "xvs": {
+      "name": "Vestinian"
+    },
+    "xwa": {
+      "name": "Kwaza"
+    },
+    "xwc": {
+      "name": "Woccon"
+    },
+    "xwd": {
+      "name": "Wadi Wadi"
+    },
+    "xwe": {
+      "name": "Xwela Gbe"
+    },
+    "xwg": {
+      "name": "Kwegu"
+    },
+    "xwj": {
+      "name": "Wajuk"
+    },
+    "xwk": {
+      "name": "Wangkumara"
+    },
+    "xwl": {
+      "name": "Western Xwla Gbe"
+    },
+    "xwo": {
+      "name": "Written Oirat"
+    },
+    "xwr": {
+      "name": "Kwerba Mamberamo"
+    },
+    "xwt": {
+      "name": "Wotjobaluk"
+    },
+    "xww": {
+      "name": "Wemba Wemba"
+    },
+    "xxb": {
+      "name": "Boro (Ghana)"
+    },
+    "xxk": {
+      "name": "Ke'o"
+    },
+    "xxm": {
+      "name": "Minkin"
+    },
+    "xxr": {
+      "name": "Koropó"
+    },
+    "xxt": {
+      "name": "Tambora"
+    },
+    "xya": {
+      "name": "Yaygir"
+    },
+    "xyb": {
+      "name": "Yandjibara"
+    },
+    "xyj": {
+      "name": "Mayi-Yapi"
+    },
+    "xyk": {
+      "name": "Mayi-Kulan"
+    },
+    "xyl": {
+      "name": "Yalakalore"
+    },
+    "xyt": {
+      "name": "Mayi-Thakurti"
+    },
+    "xyy": {
+      "name": "Yorta Yorta"
+    },
+    "xzh": {
+      "name": "Zhang-Zhung"
+    },
+    "xzm": {
+      "name": "Zemgalian"
+    },
+    "xzp": {
+      "name": "Ancient Zapotec"
+    },
+    "yaa": {
+      "name": "Yaminahua"
+    },
+    "yab": {
+      "name": "Yuhup"
+    },
+    "yac": {
+      "name": "Pass Valley Yali"
+    },
+    "yad": {
+      "name": "Yagua"
+    },
+    "yae": {
+      "name": "Pumé"
+    },
+    "yaf": {
+      "name": "Yaka (Democratic Republic of Congo)"
+    },
+    "yag": {
+      "name": "Yámana"
+    },
+    "yah": {
+      "name": "Yazgulyam"
+    },
+    "yai": {
+      "name": "Yagnobi"
+    },
+    "yaj": {
+      "name": "Banda-Yangere"
+    },
+    "yak": {
+      "name": "Yakama"
+    },
+    "yal": {
+      "name": "Yalunka"
+    },
+    "yam": {
+      "name": "Yamba"
+    },
+    "yan": {
+      "name": "Mayangna"
+    },
+    "yao": {
+      "name": "Yao"
+    },
+    "yap": {
+      "name": "Yapese"
+    },
+    "yaq": {
+      "name": "Yaqui"
+    },
+    "yar": {
+      "name": "Yabarana"
+    },
+    "yas": {
+      "name": "Nugunu (Cameroon)"
+    },
+    "yat": {
+      "name": "Yambeta"
+    },
+    "yau": {
+      "name": "Yuwana"
+    },
+    "yav": {
+      "name": "Yangben"
+    },
+    "yaw": {
+      "name": "Yawalapití"
+    },
+    "yax": {
+      "name": "Yauma"
+    },
+    "yay": {
+      "name": "Agwagwune"
+    },
+    "yaz": {
+      "name": "Lokaa"
+    },
+    "yba": {
+      "name": "Yala"
+    },
+    "ybb": {
+      "name": "Yemba"
+    },
+    "ybd": {
+      "name": "Yangbye"
+    },
+    "ybe": {
+      "name": "West Yugur"
+    },
+    "ybh": {
+      "name": "Yakha"
+    },
+    "ybi": {
+      "name": "Yamphu"
+    },
+    "ybj": {
+      "name": "Hasha"
+    },
+    "ybk": {
+      "name": "Bokha"
+    },
+    "ybl": {
+      "name": "Yukuben"
+    },
+    "ybm": {
+      "name": "Yaben"
+    },
+    "ybn": {
+      "name": "Yabaâna"
+    },
+    "ybo": {
+      "name": "Yabong"
+    },
+    "ybx": {
+      "name": "Yawiyo"
+    },
+    "yby": {
+      "name": "Yaweyuha"
+    },
+    "ych": {
+      "name": "Chesu"
+    },
+    "ycl": {
+      "name": "Lolopo"
+    },
+    "ycn": {
+      "name": "Yucuna"
+    },
+    "ycp": {
+      "name": "Chepya"
+    },
+    "yda": {
+      "name": "Yanda"
+    },
+    "ydd": {
+      "name": "Eastern Yiddish"
+    },
+    "yde": {
+      "name": "Yangum Dey"
+    },
+    "ydg": {
+      "name": "Yidgha"
+    },
+    "ydk": {
+      "name": "Yoidik"
+    },
+    "yds": {
+      "name": "Yiddish Sign Language"
+    },
+    "yea": {
+      "name": "Ravula"
+    },
+    "yec": {
+      "name": "Yeniche"
+    },
+    "yee": {
+      "name": "Yimas"
+    },
+    "yei": {
+      "name": "Yeni"
+    },
+    "yej": {
+      "name": "Yevanic"
+    },
+    "yel": {
+      "name": "Yela"
+    },
+    "yen": {
+      "name": "Yendang"
+    },
+    "yer": {
+      "name": "Tarok"
+    },
+    "yes": {
+      "name": "Nyankpa"
+    },
+    "yet": {
+      "name": "Yetfa"
+    },
+    "yeu": {
+      "name": "Yerukula"
+    },
+    "yev": {
+      "name": "Yapunda"
+    },
+    "yey": {
+      "name": "Yeyi"
+    },
+    "yga": {
+      "name": "Malyangapa"
+    },
+    "ygi": {
+      "name": "Yiningayi"
+    },
+    "ygl": {
+      "name": "Yangum Gel"
+    },
+    "ygm": {
+      "name": "Yagomi"
+    },
+    "ygp": {
+      "name": "Gepo"
+    },
+    "ygr": {
+      "name": "Yagaria"
+    },
+    "ygs": {
+      "name": "Yolŋu Sign Language"
+    },
+    "ygu": {
+      "name": "Yugul"
+    },
+    "ygw": {
+      "name": "Yagwoia"
+    },
+    "yha": {
+      "name": "Baha Buyang"
+    },
+    "yhd": {
+      "name": "Judeo-Iraqi Arabic"
+    },
+    "yhl": {
+      "name": "Hlepho Phowa"
+    },
+    "yhs": {
+      "name": "Yan-nhaŋu Sign Language"
+    },
+    "yia": {
+      "name": "Yinggarda"
+    },
+    "yif": {
+      "name": "Ache"
+    },
+    "yig": {
+      "name": "Wusa Nasu"
+    },
+    "yih": {
+      "name": "Western Yiddish"
+    },
+    "yii": {
+      "name": "Yidiny"
+    },
+    "yij": {
+      "name": "Yindjibarndi"
+    },
+    "yik": {
+      "name": "Dongshanba Lalo"
+    },
+    "yil": {
+      "name": "Yindjilandji"
+    },
+    "yim": {
+      "name": "Yimchungru Naga"
+    },
+    "yin": {
+      "name": "Yinchia"
+    },
+    "yip": {
+      "name": "Pholo"
+    },
+    "yiq": {
+      "name": "Miqie"
+    },
+    "yir": {
+      "name": "North Awyu"
+    },
+    "yis": {
+      "name": "Yis"
+    },
+    "yit": {
+      "name": "Eastern Lalu"
+    },
+    "yiu": {
+      "name": "Awu"
+    },
+    "yiv": {
+      "name": "Northern Nisu"
+    },
+    "yix": {
+      "name": "Axi Yi"
+    },
+    "yiy": {
+      "name": "Yir Yoront"
+    },
+    "yiz": {
+      "name": "Azhe"
+    },
+    "yka": {
+      "name": "Yakan"
+    },
+    "ykg": {
+      "name": "Northern Yukaghir"
+    },
+    "yki": {
+      "name": "Yoke"
+    },
+    "ykk": {
+      "name": "Yakaikeke"
+    },
+    "ykl": {
+      "name": "Khlula"
+    },
+    "ykm": {
+      "name": "Kap"
+    },
+    "ykn": {
+      "name": "Kua-nsi"
+    },
+    "yko": {
+      "name": "Yasa"
+    },
+    "ykr": {
+      "name": "Yekora"
+    },
+    "ykt": {
+      "name": "Kathu"
+    },
+    "yku": {
+      "name": "Kuamasi"
+    },
+    "yky": {
+      "name": "Yakoma"
+    },
+    "yla": {
+      "name": "Yaul"
+    },
+    "ylb": {
+      "name": "Yaleba"
+    },
+    "yle": {
+      "name": "Yele"
+    },
+    "ylg": {
+      "name": "Yelogu"
+    },
+    "yli": {
+      "name": "Angguruk Yali"
+    },
+    "yll": {
+      "name": "Yil"
+    },
+    "ylm": {
+      "name": "Limi"
+    },
+    "yln": {
+      "name": "Langnian Buyang"
+    },
+    "ylo": {
+      "name": "Naluo Yi"
+    },
+    "ylr": {
+      "name": "Yalarnnga"
+    },
+    "ylu": {
+      "name": "Aribwaung"
+    },
+    "yly": {
+      "name": "Nyâlayu"
+    },
+    "yma": {
+      "name": "Yamphe"
+    },
+    "ymb": {
+      "name": "Yambes"
+    },
+    "ymc": {
+      "name": "Southern Muji"
+    },
+    "ymd": {
+      "name": "Muda"
+    },
+    "yme": {
+      "name": "Yameo"
+    },
+    "ymg": {
+      "name": "Yamongeri"
+    },
+    "ymh": {
+      "name": "Mili"
+    },
+    "ymi": {
+      "name": "Moji"
+    },
+    "ymk": {
+      "name": "Makwe"
+    },
+    "yml": {
+      "name": "Iamalele"
+    },
+    "ymm": {
+      "name": "Maay"
+    },
+    "ymn": {
+      "name": "Yamna"
+    },
+    "ymo": {
+      "name": "Yangum Mon"
+    },
+    "ymp": {
+      "name": "Yamap"
+    },
+    "ymq": {
+      "name": "Qila Muji"
+    },
+    "ymr": {
+      "name": "Malasar"
+    },
+    "yms": {
+      "name": "Mysian"
+    },
+    "ymt": {
+      "name": "Mator-Taygi-Karagas"
+    },
+    "ymx": {
+      "name": "Northern Muji"
+    },
+    "ymz": {
+      "name": "Muzi"
+    },
+    "yna": {
+      "name": "Aluo"
+    },
+    "ynd": {
+      "name": "Yandruwandha"
+    },
+    "yne": {
+      "name": "Lang'e"
+    },
+    "yng": {
+      "name": "Yango"
+    },
+    "ynh": {
+      "name": "Yangho"
+    },
+    "ynk": {
+      "name": "Naukan Yupik"
+    },
+    "ynl": {
+      "name": "Yangulam"
+    },
+    "ynn": {
+      "name": "Yana"
+    },
+    "yno": {
+      "name": "Yong"
+    },
+    "ynq": {
+      "name": "Yendang"
+    },
+    "yns": {
+      "name": "Yansi"
+    },
+    "ynu": {
+      "name": "Yahuna"
+    },
+    "yob": {
+      "name": "Yoba"
+    },
+    "yog": {
+      "name": "Yogad"
+    },
+    "yoi": {
+      "name": "Yonaguni"
+    },
+    "yok": {
+      "name": "Yokuts"
+    },
+    "yol": {
+      "name": "Yola"
+    },
+    "yom": {
+      "name": "Yombe"
+    },
+    "yon": {
+      "name": "Yongkom"
+    },
+    "yos": {
+      "name": "Yos"
+    },
+    "yot": {
+      "name": "Yotti"
+    },
+    "yox": {
+      "name": "Yoron"
+    },
+    "yoy": {
+      "name": "Yoy"
+    },
+    "ypa": {
+      "name": "Phala"
+    },
+    "ypb": {
+      "name": "Labo Phowa"
+    },
+    "ypg": {
+      "name": "Phola"
+    },
+    "yph": {
+      "name": "Phupha"
+    },
+    "ypk": {
+      "name": "Yupik languages"
+    },
+    "ypm": {
+      "name": "Phuma"
+    },
+    "ypn": {
+      "name": "Ani Phowa"
+    },
+    "ypo": {
+      "name": "Alo Phola"
+    },
+    "ypp": {
+      "name": "Phupa"
+    },
+    "ypz": {
+      "name": "Phuza"
+    },
+    "yra": {
+      "name": "Yerakai"
+    },
+    "yrb": {
+      "name": "Yareba"
+    },
+    "yre": {
+      "name": "Yaouré"
+    },
+    "yri": {
+      "name": "Yarí"
+    },
+    "yrk": {
+      "name": "Nenets"
+    },
+    "yrl": {
+      "name": "Nhengatu"
+    },
+    "yrm": {
+      "name": "Yirrk-Mel"
+    },
+    "yrn": {
+      "name": "Yerong"
+    },
+    "yro": {
+      "name": "Yaroamë"
+    },
+    "yrs": {
+      "name": "Yarsun"
+    },
+    "yrw": {
+      "name": "Yarawata"
+    },
+    "yry": {
+      "name": "Yarluyandi"
+    },
+    "ysc": {
+      "name": "Yassic"
+    },
+    "ysd": {
+      "name": "Samatao"
+    },
+    "ysg": {
+      "name": "Sonaga"
+    },
+    "ysl": {
+      "name": "Yugoslavian Sign Language"
+    },
+    "ysn": {
+      "name": "Sani"
+    },
+    "yso": {
+      "name": "Nisi (China)"
+    },
+    "ysp": {
+      "name": "Southern Lolopo"
+    },
+    "ysr": {
+      "name": "Sirenik Yupik"
+    },
+    "yss": {
+      "name": "Yessan-Mayo"
+    },
+    "ysy": {
+      "name": "Sanie"
+    },
+    "yta": {
+      "name": "Talu"
+    },
+    "ytl": {
+      "name": "Tanglang"
+    },
+    "ytp": {
+      "name": "Thopho"
+    },
+    "ytw": {
+      "name": "Yout Wam"
+    },
+    "yty": {
+      "name": "Yatay"
+    },
+    "yua": {
+      "name": "Yucateco"
+    },
+    "yub": {
+      "name": "Yugambal"
+    },
+    "yuc": {
+      "name": "Yuchi"
+    },
+    "yud": {
+      "name": "Judeo-Tripolitanian Arabic"
+    },
+    "yue": {
+      "name": "Yue Chinese"
+    },
+    "yuf": {
+      "name": "Havasupai-Walapai-Yavapai"
+    },
+    "yug": {
+      "name": "Yug"
+    },
+    "yui": {
+      "name": "Yurutí"
+    },
+    "yuj": {
+      "name": "Karkar-Yuri"
+    },
+    "yuk": {
+      "name": "Yuki"
+    },
+    "yul": {
+      "name": "Yulu"
+    },
+    "yum": {
+      "name": "Quechan"
+    },
+    "yun": {
+      "name": "Bena (Nigeria)"
+    },
+    "yup": {
+      "name": "Yukpa"
+    },
+    "yuq": {
+      "name": "Yuqui"
+    },
+    "yur": {
+      "name": "Yurok"
+    },
+    "yut": {
+      "name": "Yopno"
+    },
+    "yuu": {
+      "name": "Yugh"
+    },
+    "yuw": {
+      "name": "Yau (Morobe Province)"
+    },
+    "yux": {
+      "name": "Southern Yukaghir"
+    },
+    "yuy": {
+      "name": "East Yugur"
+    },
+    "yuz": {
+      "name": "Yuracare"
+    },
+    "yva": {
+      "name": "Yawa"
+    },
+    "yvt": {
+      "name": "Yavitero"
+    },
+    "ywa": {
+      "name": "Kalou"
+    },
+    "ywg": {
+      "name": "Yinhawangka"
+    },
+    "ywl": {
+      "name": "Western Lalu"
+    },
+    "ywn": {
+      "name": "Yawanawa"
+    },
+    "ywq": {
+      "name": "Wuding-Luquan Yi"
+    },
+    "ywr": {
+      "name": "Yawuru"
+    },
+    "ywt": {
+      "name": "Xishanba Lalo"
+    },
+    "ywu": {
+      "name": "Wumeng Nasu"
+    },
+    "yww": {
+      "name": "Yawarawarga"
+    },
+    "yxa": {
+      "name": "Mayawali"
+    },
+    "yxg": {
+      "name": "Yagara"
+    },
+    "yxl": {
+      "name": "Yardliyawarra"
+    },
+    "yxm": {
+      "name": "Yinwum"
+    },
+    "yxu": {
+      "name": "Yuyu"
+    },
+    "yxy": {
+      "name": "Yabula Yabula"
+    },
+    "yyr": {
+      "name": "Yir Yoront"
+    },
+    "yyu": {
+      "name": "Yau (Sandaun Province)"
+    },
+    "yyz": {
+      "name": "Ayizi"
+    },
+    "yzg": {
+      "name": "E'ma Buyang"
+    },
+    "yzk": {
+      "name": "Zokhuo"
+    },
+    "zaa": {
+      "name": "Sierra de Juárez Zapotec"
+    },
+    "zab": {
+      "name": "Western Tlacolula Valley Zapotec"
+    },
+    "zac": {
+      "name": "Ocotlán Zapotec"
+    },
+    "zad": {
+      "name": "Cajonos Zapotec"
+    },
+    "zae": {
+      "name": "Yareni Zapotec"
+    },
+    "zaf": {
+      "name": "Ayoquesco Zapotec"
+    },
+    "zag": {
+      "name": "Zaghawa"
+    },
+    "zah": {
+      "name": "Zangwal"
+    },
+    "zai": {
+      "name": "Isthmus Zapotec"
+    },
+    "zaj": {
+      "name": "Zaramo"
+    },
+    "zak": {
+      "name": "Zanaki"
+    },
+    "zal": {
+      "name": "Zauzou"
+    },
+    "zam": {
+      "name": "Miahuatlán Zapotec"
+    },
+    "zao": {
+      "name": "Ozolotepec Zapotec"
+    },
+    "zap": {
+      "name": "Zapotec"
+    },
+    "zaq": {
+      "name": "Aloápam Zapotec"
+    },
+    "zar": {
+      "name": "Rincón Zapotec"
+    },
+    "zas": {
+      "name": "Santo Domingo Albarradas Zapotec"
+    },
+    "zat": {
+      "name": "Tabaa Zapotec"
+    },
+    "zau": {
+      "name": "Zangskari"
+    },
+    "zav": {
+      "name": "Yatzachi Zapotec"
+    },
+    "zaw": {
+      "name": "Mitla Zapotec"
+    },
+    "zax": {
+      "name": "Xadani Zapotec"
+    },
+    "zay": {
+      "name": "Zayse-Zergulla"
+    },
+    "zaz": {
+      "name": "Zari"
+    },
+    "zbc": {
+      "name": "Central Berawan"
+    },
+    "zbe": {
+      "name": "East Berawan"
+    },
+    "zbl": {
+      "name": "Blissymbols"
+    },
+    "zbt": {
+      "name": "Batui"
+    },
+    "zbw": {
+      "name": "West Berawan"
+    },
+    "zca": {
+      "name": "Coatecas Altas Zapotec"
+    },
+    "zch": {
+      "name": "Central Hongshuihe Zhuang"
+    },
+    "zdj": {
+      "name": "Ngazidja Comorian"
+    },
+    "zea": {
+      "name": "Zeeuws"
+    },
+    "zeg": {
+      "name": "Zenag"
+    },
+    "zeh": {
+      "name": "Eastern Hongshuihe Zhuang"
+    },
+    "zen": {
+      "name": "Zenaga"
+    },
+    "zga": {
+      "name": "Kinga"
+    },
+    "zgb": {
+      "name": "Guibei Zhuang"
+    },
+    "zgh": {
+      "name": "Standard Moroccan Tamazight"
+    },
+    "zgm": {
+      "name": "Minz Zhuang"
+    },
+    "zgn": {
+      "name": "Guibian Zhuang"
+    },
+    "zgr": {
+      "name": "Magori"
+    },
+    "zhb": {
+      "name": "Zhaba"
+    },
+    "zhd": {
+      "name": "Dai Zhuang"
+    },
+    "zhi": {
+      "name": "Zhire"
+    },
+    "zhn": {
+      "name": "Nong Zhuang"
+    },
+    "zhw": {
+      "name": "Zhoa"
+    },
+    "zhx": {
+      "name": "Chinese (family)"
+    },
+    "zia": {
+      "name": "Zia"
+    },
+    "zib": {
+      "name": "Zimbabwe Sign Language"
+    },
+    "zik": {
+      "name": "Zimakani"
+    },
+    "zil": {
+      "name": "Zialo"
+    },
+    "zim": {
+      "name": "Mesme"
+    },
+    "zin": {
+      "name": "Zinza"
+    },
+    "zir": {
+      "name": "Ziriya"
+    },
+    "ziw": {
+      "name": "Zigula"
+    },
+    "ziz": {
+      "name": "Zizilivakan"
+    },
+    "zka": {
+      "name": "Kaimbulawa"
+    },
+    "zkb": {
+      "name": "Koibal"
+    },
+    "zkd": {
+      "name": "Kadu"
+    },
+    "zkg": {
+      "name": "Koguryo"
+    },
+    "zkh": {
+      "name": "Khorezmian"
+    },
+    "zkk": {
+      "name": "Karankawa"
+    },
+    "zkn": {
+      "name": "Kanan"
+    },
+    "zko": {
+      "name": "Kott"
+    },
+    "zkp": {
+      "name": "São Paulo Kaingáng"
+    },
+    "zkr": {
+      "name": "Zakhring"
+    },
+    "zkt": {
+      "name": "Kitan"
+    },
+    "zku": {
+      "name": "Kaurna"
+    },
+    "zkv": {
+      "name": "Krevinian"
+    },
+    "zkz": {
+      "name": "Khazar"
+    },
+    "zle": {
+      "name": "East Slavic languages"
+    },
+    "zlj": {
+      "name": "Liujiang Zhuang"
+    },
+    "zlm": {
+      "name": "Malay (individual language)"
+    },
+    "zln": {
+      "name": "Lianshan Zhuang"
+    },
+    "zlq": {
+      "name": "Liuqian Zhuang"
+    },
+    "zls": {
+      "name": "South Slavic languages"
+    },
+    "zlw": {
+      "name": "West Slavic languages"
+    },
+    "zma": {
+      "name": "Manda (Australia)"
+    },
+    "zmb": {
+      "name": "Zimba"
+    },
+    "zmc": {
+      "name": "Margany"
+    },
+    "zmd": {
+      "name": "Maridan"
+    },
+    "zme": {
+      "name": "Mangerr"
+    },
+    "zmf": {
+      "name": "Mfinu"
+    },
+    "zmg": {
+      "name": "Marti Ke"
+    },
+    "zmh": {
+      "name": "Makolkol"
+    },
+    "zmi": {
+      "name": "Negeri Sembilan Malay"
+    },
+    "zmj": {
+      "name": "Maridjabin"
+    },
+    "zmk": {
+      "name": "Mandandanyi"
+    },
+    "zml": {
+      "name": "Madngele"
+    },
+    "zmm": {
+      "name": "Marimanindji"
+    },
+    "zmn": {
+      "name": "Mbangwe"
+    },
+    "zmo": {
+      "name": "Molo"
+    },
+    "zmp": {
+      "name": "Mpuono"
+    },
+    "zmq": {
+      "name": "Mituku"
+    },
+    "zmr": {
+      "name": "Maranunggu"
+    },
+    "zms": {
+      "name": "Mbesa"
+    },
+    "zmt": {
+      "name": "Maringarr"
+    },
+    "zmu": {
+      "name": "Muruwari"
+    },
+    "zmv": {
+      "name": "Mbariman-Gudhinma"
+    },
+    "zmw": {
+      "name": "Mbo (Democratic Republic of Congo)"
+    },
+    "zmx": {
+      "name": "Bomitaba"
+    },
+    "zmy": {
+      "name": "Mariyedi"
+    },
+    "zmz": {
+      "name": "Mbandja"
+    },
+    "zna": {
+      "name": "Zan Gula"
+    },
+    "znd": {
+      "name": "Zande languages"
+    },
+    "zne": {
+      "name": "Zande (individual language)"
+    },
+    "zng": {
+      "name": "Mang"
+    },
+    "znk": {
+      "name": "Manangkari"
+    },
+    "zns": {
+      "name": "Mangas"
+    },
+    "zoc": {
+      "name": "Copainalá Zoque"
+    },
+    "zoh": {
+      "name": "Chimalapa Zoque"
+    },
+    "zom": {
+      "name": "Zou"
+    },
+    "zoo": {
+      "name": "Asunción Mixtepec Zapotec"
+    },
+    "zoq": {
+      "name": "Tabasco Zoque"
+    },
+    "zor": {
+      "name": "Rayón Zoque"
+    },
+    "zos": {
+      "name": "Francisco León Zoque"
+    },
+    "zpa": {
+      "name": "Lachiguiri Zapotec"
+    },
+    "zpb": {
+      "name": "Yautepec Zapotec"
+    },
+    "zpc": {
+      "name": "Choapan Zapotec"
+    },
+    "zpd": {
+      "name": "Southeastern Ixtlán Zapotec"
+    },
+    "zpe": {
+      "name": "Petapa Zapotec"
+    },
+    "zpf": {
+      "name": "San Pedro Quiatoni Zapotec"
+    },
+    "zpg": {
+      "name": "Guevea De Humboldt Zapotec"
+    },
+    "zph": {
+      "name": "Totomachapan Zapotec"
+    },
+    "zpi": {
+      "name": "Santa María Quiegolani Zapotec"
+    },
+    "zpj": {
+      "name": "Quiavicuzas Zapotec"
+    },
+    "zpk": {
+      "name": "Tlacolulita Zapotec"
+    },
+    "zpl": {
+      "name": "Lachixío Zapotec"
+    },
+    "zpm": {
+      "name": "Mixtepec Zapotec"
+    },
+    "zpn": {
+      "name": "Santa Inés Yatzechi Zapotec"
+    },
+    "zpo": {
+      "name": "Amatlán Zapotec"
+    },
+    "zpp": {
+      "name": "El Alto Zapotec"
+    },
+    "zpq": {
+      "name": "Zoogocho Zapotec"
+    },
+    "zpr": {
+      "name": "Santiago Xanica Zapotec"
+    },
+    "zps": {
+      "name": "Coatlán Zapotec"
+    },
+    "zpt": {
+      "name": "San Vicente Coatlán Zapotec"
+    },
+    "zpu": {
+      "name": "Yalálag Zapotec"
+    },
+    "zpv": {
+      "name": "Chichicapan Zapotec"
+    },
+    "zpw": {
+      "name": "Zaniza Zapotec"
+    },
+    "zpx": {
+      "name": "San Baltazar Loxicha Zapotec"
+    },
+    "zpy": {
+      "name": "Mazaltepec Zapotec"
+    },
+    "zpz": {
+      "name": "Texmelucan Zapotec"
+    },
+    "zqe": {
+      "name": "Qiubei Zhuang"
+    },
+    "zra": {
+      "name": "Kara (Korea)"
+    },
+    "zrg": {
+      "name": "Mirgan"
+    },
+    "zrn": {
+      "name": "Zerenkel"
+    },
+    "zro": {
+      "name": "Záparo"
+    },
+    "zrp": {
+      "name": "Zarphatic"
+    },
+    "zrs": {
+      "name": "Mairasi"
+    },
+    "zsa": {
+      "name": "Sarasira"
+    },
+    "zsk": {
+      "name": "Kaskean"
+    },
+    "zsl": {
+      "name": "Zambian Sign Language"
+    },
+    "zsm": {
+      "name": "Standard Malay"
+    },
+    "zsr": {
+      "name": "Southern Rincon Zapotec"
+    },
+    "zsu": {
+      "name": "Sukurum"
+    },
+    "zte": {
+      "name": "Elotepec Zapotec"
+    },
+    "ztg": {
+      "name": "Xanaguía Zapotec"
+    },
+    "ztl": {
+      "name": "Lapaguía-Guivini Zapotec"
+    },
+    "ztm": {
+      "name": "San Agustín Mixtepec Zapotec"
+    },
+    "ztn": {
+      "name": "Santa Catarina Albarradas Zapotec"
+    },
+    "ztp": {
+      "name": "Loxicha Zapotec"
+    },
+    "ztq": {
+      "name": "Quioquitani-Quierí Zapotec"
+    },
+    "zts": {
+      "name": "Tilquiapan Zapotec"
+    },
+    "ztt": {
+      "name": "Tejalapan Zapotec"
+    },
+    "ztu": {
+      "name": "Güilá Zapotec"
+    },
+    "ztx": {
+      "name": "Zaachila Zapotec"
+    },
+    "zty": {
+      "name": "Yatee Zapotec"
+    },
+    "zua": {
+      "name": "Zeem"
+    },
+    "zuh": {
+      "name": "Tokano"
+    },
+    "zum": {
+      "name": "Kumzari"
+    },
+    "zun": {
+      "name": "Zuni"
+    },
+    "zuy": {
+      "name": "Zumaya"
+    },
+    "zwa": {
+      "name": "Zay"
+    },
+    "zxx": {
+      "name": "No linguistic content"
+    },
+    "zyb": {
+      "name": "Yongbei Zhuang"
+    },
+    "zyg": {
+      "name": "Yang Zhuang"
+    },
+    "zyj": {
+      "name": "Youjiang Zhuang"
+    },
+    "zyn": {
+      "name": "Yongnan Zhuang"
+    },
+    "zyp": {
+      "name": "Zyphe Chin"
+    },
+    "zza": {
+      "name": "Zaza"
+    },
+    "zzj": {
+      "name": "Zuojiang Zhuang"
+    }
+  }
+}

--- a/src/Resources/ReadMe.md
+++ b/src/Resources/ReadMe.md
@@ -1,0 +1,2 @@
+- CountryCodes list manually generated from http://www.nationsonline.org/oneworld/country_code_list.htm (copied 24 Jun 2018)
+- Language Codes list manually generated from http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry (File-Date: 2018-04-23)

--- a/src/index.css
+++ b/src/index.css
@@ -8,38 +8,46 @@ body {
   max-width: 100%;
 }
 
+.thead .Polaris-Link {
+  color: #fff;
+}
+
+.thead .Polaris-Link:active, .thead .Polaris-Link:focus, .thead .Polaris-Link:hover {
+  color: #F6F0FD;
+}
+
 /* ----------------------------------------------------------
    Scrolling table with fixed header & first column
     (adapted from https://codepen.io/MaxArt2501/pen/qLCmE ) */
 .fix-column {
-    float: left;
+  float: left;
 }
 .thead {
-    height: 40px;
-    white-space: nowrap;
+  height: 40px;
+  white-space: nowrap;
 }
 .fix-column > .thead > span {
-    width: 210px;
+  width: 210px;
 }
 .thead > span {
-    display: inline-block;
-    width: 120px;
-    line-height: 40px;
-    box-shadow: inset 0 0 1px 0 rgba(0,0,0,.5);
-    background-color: #43467F;  /* Polaris "Title bar" */
-    color: #fff;
-    text-align: center;
+  display: inline-block;
+  width: 120px;
+  line-height: 40px;
+  box-shadow: inset 0 0 1px 0 rgba(0,0,0,.5);
+  background-color: #43467F;  /* Polaris "Title bar" */
+  color: #fff;
+  text-align: center;
 }
 .trow {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 .trow > span {
-    display: inline-block;
-    width: 120px;
-    box-shadow: inset 0 0 1px 0 rgba(0,0,0,.5);
-    line-height: 50px;
-    height: 50px;
-    text-align: center; 
+  display: inline-block;
+  width: 120px;
+  box-shadow: inset 0 0 1px 0 rgba(0,0,0,.5);
+  line-height: 50px;
+  height: 50px;
+  text-align: center; 
 }
 .fix-column > .tbody > .trow > span {
   width: 210px;
@@ -48,39 +56,39 @@ body {
   padding-left: 8px;
 }
 .tbody {
-    height: 700px;  /*  TODO:  try using flexbox to make it screen-height */
-    overflow: auto;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+  height: 700px;  /*  TODO:  try using flexbox to make it screen-height */
+  overflow: auto;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 .fix-column > .tbody {
-    overflow: hidden;
-    /*padding-bottom: 50px;*/
+  overflow: hidden;
 }
-/*.fix-column > .tbody > .trow:last-child {margin-bottom: 50px;}*/
 
 .fix-column > .tbody > .trow {
-    margin-top: -50px;
-    margin-bottom: 50px;
+  margin-top: -50px;
+  margin-bottom: 50px;
 }
 .fix-column > .tbody > .trow:first-child {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 .rest-columns {
-    width: 100%;
+  width: 100%;
 }
 .rest-columns > .thead {
-    /*padding-right: 50px;*/
-    overflow: hidden;
+  overflow: hidden;
 }
-/*.rest-columns > .thead > :last-child {margin-right: 50px;}*/
 .rest-columns > .thead > span {
-    margin-right: 50px;
-    margin-left: -50px;
+  margin-right: 50px;
+  margin-left: -50px;
 }
 .rest-columns > .thead > :first-child {margin-left: 0px;}
 
 /* ----------------------------------------------------------
    END of Scrolling table with fixed header & first column
 */
+
+.coloured-column {
+  background-color: #B3BCF5; /* Polaris indigo light  TODO:  try using the name ... */
+}


### PR DESCRIPTION
- Added column shading to visually group instances of the same language together. 
- Added tooltips to the locale-headings to show the full name of the language and country